### PR TITLE
refactor init and use size adapter

### DIFF
--- a/validator/src/main/java/io/avaje/validation/AnnotationValidationAdapter.java
+++ b/validator/src/main/java/io/avaje/validation/AnnotationValidationAdapter.java
@@ -1,17 +1,16 @@
-package io.avaje.validation.adapter;
+package io.avaje.validation;
 
 import java.lang.reflect.Type;
 import java.util.Map;
-import java.util.Objects;
 
-import io.avaje.validation.Validator;
+import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.core.MessageInterpolator;
 
 public interface AnnotationValidationAdapter<T> extends ValidationAdapter<T> {
 
   //void validate(T type, ValidationRequest req);
 
-  default AnnotationValidationAdapter<T> init(Map<String, String> annotationValueMap) {
+  default AnnotationValidationAdapter<T> init(Map<String, Object> annotationValueMap) {
     return this;
   }
 

--- a/validator/src/main/java/io/avaje/validation/ConstraintViolation.java
+++ b/validator/src/main/java/io/avaje/validation/ConstraintViolation.java
@@ -29,4 +29,10 @@ public class ConstraintViolation {
   public String message() {
     return message;
   }
+
+  @Override
+  public String toString() {
+
+    return message;
+  }
 }

--- a/validator/src/main/java/io/avaje/validation/Validator.java
+++ b/validator/src/main/java/io/avaje/validation/Validator.java
@@ -1,16 +1,17 @@
 package io.avaje.validation;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.ServiceLoader;
+
 import io.avaje.validation.adapter.AnnotationValidationAdapter;
 import io.avaje.validation.adapter.CoreValidation;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidatorComponent;
 import io.avaje.validation.core.DefaultBootstrap;
 import io.avaje.validation.spi.Bootstrap;
-
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
-import java.util.Iterator;
-import java.util.ServiceLoader;
 
 public interface Validator {
 
@@ -29,7 +30,7 @@ public interface Validator {
 
   <T> ValidationAdapter<T> adapter(Type type);
 
-  <T> AnnotationValidationAdapter<T> annotationAdapter(Class<? extends Annotation> cls);
+  <T> AnnotationValidationAdapter<T> annotationAdapter(Class<? extends Annotation> cls, Map<String ,String> annotationAttributes);
 
   CoreValidation core();
 

--- a/validator/src/main/java/io/avaje/validation/Validator.java
+++ b/validator/src/main/java/io/avaje/validation/Validator.java
@@ -6,7 +6,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.ServiceLoader;
 
-import io.avaje.validation.adapter.AnnotationValidationAdapter;
 import io.avaje.validation.adapter.CoreValidation;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidatorComponent;
@@ -30,7 +29,7 @@ public interface Validator {
 
   <T> ValidationAdapter<T> adapter(Type type);
 
-  <T> AnnotationValidationAdapter<T> annotationAdapter(Class<? extends Annotation> cls, Map<String ,String> annotationAttributes);
+  <T> AnnotationValidationAdapter<T> annotationAdapter(Class<? extends Annotation> cls, Map<String, Object> annotationAttributes);
 
   CoreValidation core();
 

--- a/validator/src/main/java/io/avaje/validation/adapter/CoreValidation.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/CoreValidation.java
@@ -1,11 +1,7 @@
 package io.avaje.validation.adapter;
 
-import java.util.Collection;
-
 public interface CoreValidation {
 
     /** Return true to continue validation on this value if needed */
     boolean required(Object value, ValidationRequest ctx, String propertyName);
-
-    boolean collection(ValidationRequest ctx, String propertyName, Collection<?> collection, int minSize, int maxSize);
 }

--- a/validator/src/main/java/io/avaje/validation/adapter/ValidationAdapter.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/ValidationAdapter.java
@@ -15,6 +15,7 @@
  */
 package io.avaje.validation.adapter;
 
+import io.avaje.validation.AnnotationValidationAdapter;
 import io.avaje.validation.Validator;
 
 import java.lang.reflect.Type;

--- a/validator/src/main/java/io/avaje/validation/adapter/ValidationAdapter.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/ValidationAdapter.java
@@ -44,6 +44,20 @@ public interface ValidationAdapter<T> {
     return true;
   }
 
+  default boolean validateAll(T[] value, ValidationRequest req, String propertName) {
+    if (propertName != null) {
+      req.pushPath(propertName);
+    }
+    int index = -1;
+    for (T element : value) {
+      validate(element, req, String.valueOf(++index));
+    }
+    if (propertName != null) {
+      req.popPath();
+    }
+    return true;
+  }
+
   default AnnotationValidationAdapter<T> andThen(ValidationAdapter<? super T> after) {
     Objects.requireNonNull(after);
     return (value, req, propertyName) -> {

--- a/validator/src/main/java/io/avaje/validation/core/CoreAdapterBuilder.java
+++ b/validator/src/main/java/io/avaje/validation/core/CoreAdapterBuilder.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import io.avaje.validation.adapter.AnnotationValidationAdapter;
+import io.avaje.validation.AnnotationValidationAdapter;
 import io.avaje.validation.adapter.ValidationAdapter;
 
 /** Builds and caches the ValidationAdapter adapters for DValidator. */

--- a/validator/src/main/java/io/avaje/validation/core/DCoreValidation.java
+++ b/validator/src/main/java/io/avaje/validation/core/DCoreValidation.java
@@ -3,8 +3,6 @@ package io.avaje.validation.core;
 import io.avaje.validation.adapter.CoreValidation;
 import io.avaje.validation.adapter.ValidationRequest;
 
-import java.util.Collection;
-
 final class DCoreValidation implements CoreValidation {
 
     @Override
@@ -14,24 +12,5 @@ final class DCoreValidation implements CoreValidation {
             return false;
         }
         return true;
-    }
-
-    @Override
-    public boolean collection(ValidationRequest ctx, String propertyName, Collection<?> collection, int minSize, int maxSize) {
-        if (collection == null) {
-            if (minSize != -1) {
-                ctx.addViolation("CollectionNull", propertyName);
-            }
-            return false;
-        }
-        final int size = collection.size();
-        if (size < minSize) {
-            ctx.addViolation("CollectionMinSize", propertyName);
-        }
-        if (maxSize > 0 && size > maxSize) {
-            ctx.addViolation("CollectionMaxSize", propertyName);
-        }
-        // also validate the collection elements
-        return size > 0;
     }
 }

--- a/validator/src/main/java/io/avaje/validation/core/DValidator.java
+++ b/validator/src/main/java/io/avaje/validation/core/DValidator.java
@@ -8,18 +8,17 @@ import static java.util.Objects.requireNonNull;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.avaje.validation.ValidationType;
+import io.avaje.validation.Validator;
 import io.avaje.validation.adapter.AnnotationValidationAdapter;
 import io.avaje.validation.adapter.AnnotationValidationAdapter.Factory;
 import io.avaje.validation.adapter.CoreValidation;
 import io.avaje.validation.adapter.ValidationAdapter;
-import io.avaje.validation.ValidationType;
-import io.avaje.validation.Validator;
 import io.avaje.validation.adapter.ValidatorComponent;
 
 /** Default implementation of Validator. */
@@ -77,9 +76,9 @@ final class DValidator implements Validator {
 
   @Override
   public <T> AnnotationValidationAdapter<T> annotationAdapter(
-      Class<? extends Annotation> cls) {
+      Class<? extends Annotation> cls, Map<String, String> annotationAttributes) {
 
-    return builder.annotationAdapter(cls);
+    return builder.<T>annotationAdapter(cls).init(annotationAttributes);
   }
 
   @Override

--- a/validator/src/main/java/io/avaje/validation/core/DValidator.java
+++ b/validator/src/main/java/io/avaje/validation/core/DValidator.java
@@ -13,10 +13,10 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.avaje.validation.AnnotationValidationAdapter;
+import io.avaje.validation.AnnotationValidationAdapter.Factory;
 import io.avaje.validation.ValidationType;
 import io.avaje.validation.Validator;
-import io.avaje.validation.adapter.AnnotationValidationAdapter;
-import io.avaje.validation.adapter.AnnotationValidationAdapter.Factory;
 import io.avaje.validation.adapter.CoreValidation;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidatorComponent;
@@ -76,7 +76,7 @@ final class DValidator implements Validator {
 
   @Override
   public <T> AnnotationValidationAdapter<T> annotationAdapter(
-      Class<? extends Annotation> cls, Map<String, String> annotationAttributes) {
+      Class<? extends Annotation> cls, Map<String, Object> annotationAttributes) {
 
     return builder.<T>annotationAdapter(cls).init(annotationAttributes);
   }

--- a/validator/src/main/java/io/avaje/validation/core/DefaultBootstrap.java
+++ b/validator/src/main/java/io/avaje/validation/core/DefaultBootstrap.java
@@ -4,6 +4,7 @@ import io.avaje.validation.Validator;
 
 /** Default bootstrap of Validator. */
 public final class DefaultBootstrap {
+  private DefaultBootstrap() {}
 
   /** Create the Validator.Builder. */
   public static Validator.Builder builder() {

--- a/validator/src/main/java/io/avaje/validation/core/JakartaTypeAdapters.java
+++ b/validator/src/main/java/io/avaje/validation/core/JakartaTypeAdapters.java
@@ -64,6 +64,13 @@ final class JakartaTypeAdapters {
     @Override
     public boolean validate(Object value, ValidationRequest req, String propertyName) {
 
+      if (value == null) {
+        if (min != -1) {
+          req.addViolation("CollectionNull", propertyName);
+        }
+        return false;
+      }
+
       if (value instanceof CharSequence) {
         final var sequence = (CharSequence) value;
         final var len = sequence.length();
@@ -78,7 +85,7 @@ final class JakartaTypeAdapters {
         final var len = col.size();
         if (len > max || len < min) {
           req.addViolation(message, propertyName);
-          return false;
+          return len > 0;
         }
       }
 
@@ -87,7 +94,7 @@ final class JakartaTypeAdapters {
         final var len = col.size();
         if (len > max || len < min) {
           req.addViolation(message, propertyName);
-          return false;
+          return len > 0;
         }
       }
 
@@ -96,7 +103,7 @@ final class JakartaTypeAdapters {
         final var len = Array.getLength(value);
         if (len > max || len < min) {
           req.addViolation(message, propertyName);
-          return false;
+          return len > 0;
         }
       }
 
@@ -121,7 +128,8 @@ final class JakartaTypeAdapters {
     }
 
     @Override
-    public boolean validate(TemporalAccessor temporalAccessor, ValidationRequest req, String propertyName) {
+    public boolean validate(
+        TemporalAccessor temporalAccessor, ValidationRequest req, String propertyName) {
       if (temporalAccessor == null) {
         req.addViolation(message, propertyName);
         return false;

--- a/validator/src/main/java/io/avaje/validation/core/JakartaTypeAdapters.java
+++ b/validator/src/main/java/io/avaje/validation/core/JakartaTypeAdapters.java
@@ -22,7 +22,7 @@ import java.time.temporal.TemporalAccessor;
 import java.util.Collection;
 import java.util.Map;
 
-import io.avaje.validation.adapter.AnnotationValidationAdapter;
+import io.avaje.validation.AnnotationValidationAdapter;
 import io.avaje.validation.adapter.ValidationRequest;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
@@ -54,10 +54,10 @@ final class JakartaTypeAdapters {
     }
 
     @Override
-    public AnnotationValidationAdapter<Object> init(Map<String, String> annotationValueMap) {
-      message = interpolator.interpolate(annotationValueMap.get("message"));
-      min = Integer.parseInt(interpolator.interpolate(annotationValueMap.get("min")));
-      max = Integer.parseInt(interpolator.interpolate(annotationValueMap.get("max")));
+    public AnnotationValidationAdapter<Object> init(Map<String, Object> annotationValueMap) {
+      message = interpolator.interpolate((String) annotationValueMap.get("message"));
+      min = (int) annotationValueMap.get("min");
+      max = (int) annotationValueMap.get("max");
       return this;
     }
 
@@ -122,8 +122,8 @@ final class JakartaTypeAdapters {
 
     @Override
     public AnnotationValidationAdapter<TemporalAccessor> init(
-        Map<String, String> annotationValueMap) {
-      message = interpolator.interpolate(annotationValueMap.get("message"));
+        Map<String, Object> annotationValueMap) {
+      message = interpolator.interpolate((String) annotationValueMap.get("message"));
       return this;
     }
 
@@ -159,8 +159,8 @@ final class JakartaTypeAdapters {
     }
 
     @Override
-    public AnnotationValidationAdapter<String> init(Map<String, String> annotationValueMap) {
-      message = interpolator.interpolate(annotationValueMap.get("message"));
+    public AnnotationValidationAdapter<String> init(Map<String, Object> annotationValueMap) {
+      message = interpolator.interpolate((String) annotationValueMap.get("message"));
       return this;
     }
 
@@ -184,8 +184,8 @@ final class JakartaTypeAdapters {
     }
 
     @Override
-    public AnnotationValidationAdapter<Boolean> init(Map<String, String> annotationValueMap) {
-      message = interpolator.interpolate(annotationValueMap.get("message"));
+    public AnnotationValidationAdapter<Boolean> init(Map<String, Object> annotationValueMap) {
+      message = interpolator.interpolate((String) annotationValueMap.get("message"));
       return this;
     }
 

--- a/validator/src/main/java/io/avaje/validation/core/NoopAnnotationValidator.java
+++ b/validator/src/main/java/io/avaje/validation/core/NoopAnnotationValidator.java
@@ -1,6 +1,6 @@
 package io.avaje.validation.core;
 
-import io.avaje.validation.adapter.AnnotationValidationAdapter;
+import io.avaje.validation.AnnotationValidationAdapter;
 import io.avaje.validation.adapter.ValidationRequest;
 
 public class NoopAnnotationValidator<T> implements AnnotationValidationAdapter<T> {

--- a/validator/src/test/java/io/avaje/validation/core/AddressValidationAdapter.java
+++ b/validator/src/test/java/io/avaje/validation/core/AddressValidationAdapter.java
@@ -2,8 +2,8 @@ package io.avaje.validation.core;
 
 import java.util.Map;
 
+import io.avaje.validation.AnnotationValidationAdapter;
 import io.avaje.validation.Validator;
-import io.avaje.validation.adapter.AnnotationValidationAdapter;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidationRequest;
 import jakarta.validation.constraints.NotBlank;

--- a/validator/src/test/java/io/avaje/validation/core/AddressValidationAdapter.java
+++ b/validator/src/test/java/io/avaje/validation/core/AddressValidationAdapter.java
@@ -1,15 +1,13 @@
 package io.avaje.validation.core;
 
+import java.util.Map;
+
 import io.avaje.validation.Validator;
 import io.avaje.validation.adapter.AnnotationValidationAdapter;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidationRequest;
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Past;
-
-import java.util.Map;
 
 public final class AddressValidationAdapter implements ValidationAdapter<Address> {
 
@@ -20,11 +18,9 @@ public final class AddressValidationAdapter implements ValidationAdapter<Address
   public AddressValidationAdapter(Validator validator) {
     this.line1Adapter =
         validator
-            .<String>annotationAdapter(NotNull.class)
-            .init(Map.of("message", "null"))
+            .<String>annotationAdapter(NotNull.class, Map.of("message", "null"))
             .andThen(
-                validator.<String>annotationAdapter(NotBlank.class).init(Map.of("message", "empty")));
-
+                validator.annotationAdapter(NotBlank.class, Map.of("message", "empty")));
   }
 
   @Override

--- a/validator/src/test/java/io/avaje/validation/core/ContactValidationAdapter.java
+++ b/validator/src/test/java/io/avaje/validation/core/ContactValidationAdapter.java
@@ -2,8 +2,8 @@ package io.avaje.validation.core;
 
 import java.util.Map;
 
+import io.avaje.validation.AnnotationValidationAdapter;
 import io.avaje.validation.Validator;
-import io.avaje.validation.adapter.AnnotationValidationAdapter;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidationRequest;
 import jakarta.validation.constraints.NotBlank;

--- a/validator/src/test/java/io/avaje/validation/core/ContactValidationAdapter.java
+++ b/validator/src/test/java/io/avaje/validation/core/ContactValidationAdapter.java
@@ -1,5 +1,7 @@
 package io.avaje.validation.core;
 
+import java.util.Map;
+
 import io.avaje.validation.Validator;
 import io.avaje.validation.adapter.AnnotationValidationAdapter;
 import io.avaje.validation.adapter.ValidationAdapter;
@@ -7,25 +9,20 @@ import io.avaje.validation.adapter.ValidationRequest;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-import java.util.Map;
-
 public final class ContactValidationAdapter implements ValidationAdapter<Contact> {
 
   private final AnnotationValidationAdapter<String> firstNameAdapter;
   private final AnnotationValidationAdapter<String> lastNameAdapter;
   private final ValidationAdapter<Address> addressValidator;
 
-
   public ContactValidationAdapter(Validator validator) {
     this.firstNameAdapter =
         validator
-            .<String>annotationAdapter(NotNull.class)
-            .init(Map.of("message", "null"))
-            .andThen(
-                validator.<String>annotationAdapter(NotBlank.class).init(Map.of("message", "empty")));
+            .<String>annotationAdapter(NotNull.class, Map.of("message", "null"))
+            .andThen(validator.annotationAdapter(NotBlank.class, Map.of("message", "empty")));
 
-    this.lastNameAdapter =  validator
-            .<String>annotationAdapter(NotNull.class);
+    this.lastNameAdapter =
+        validator.<String>annotationAdapter(NotNull.class, Map.of("message", "null"));
     this.addressValidator = validator.adapter(Address.class);
   }
 

--- a/validator/src/test/java/io/avaje/validation/core/Customer.java
+++ b/validator/src/test/java/io/avaje/validation/core/Customer.java
@@ -1,10 +1,11 @@
 package io.avaje.validation.core;
 
-import io.avaje.validation.ValidPojo;
-
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+
+import io.avaje.validation.ValidPojo;
+import jakarta.validation.constraints.Size;
 
 @ValidPojo
 public class Customer {
@@ -17,6 +18,7 @@ public class Customer {
   // Optional | Nullable
   public Address shippingAddress;
 
+  @Size(min = 0, max = 2)
   public List<Contact> contacts = new ArrayList<>();
 
   public Customer(boolean active, String name, LocalDate activeDate) {

--- a/validator/src/test/java/io/avaje/validation/core/CustomerValidationAdapter.java
+++ b/validator/src/test/java/io/avaje/validation/core/CustomerValidationAdapter.java
@@ -40,7 +40,7 @@ public final class CustomerValidationAdapter implements ValidationAdapter<Custom
 
     this.contactsValidator =
         validator.<List<Contact>>annotationAdapter(
-            Size.class, Map.of("message", "not sized correctly", "min", "0", "max", "2"));
+            Size.class, Map.of("message", "not sized correctly", "min", 0, "max", 2));
 
     addressValidator = validator.adapter(Address.class);
     contactValidator = validator.adapter(Contact.class);

--- a/validator/src/test/java/io/avaje/validation/core/CustomerValidationAdapter.java
+++ b/validator/src/test/java/io/avaje/validation/core/CustomerValidationAdapter.java
@@ -63,7 +63,7 @@ public final class CustomerValidationAdapter implements ValidationAdapter<Custom
     }
 
     final var _contacts = value.contacts;
-    //if field is nullable we could do _contacts != && contactsValidator.validate
+    //if field is nullable we could do _contacts != null && contactsValidator.validate
     if (contactsValidator.validate(_contacts, request, "contacts")) {
       contactValidator.validateAll(_contacts, request, "contacts");
     }

--- a/validator/src/test/java/io/avaje/validation/core/CustomerValidationAdapter.java
+++ b/validator/src/test/java/io/avaje/validation/core/CustomerValidationAdapter.java
@@ -63,6 +63,7 @@ public final class CustomerValidationAdapter implements ValidationAdapter<Custom
     }
 
     final var _contacts = value.contacts;
+    //if field is nullable we could do _contacts != && contactsValidator.validate
     if (contactsValidator.validate(_contacts, request, "contacts")) {
       contactValidator.validateAll(_contacts, request, "contacts");
     }

--- a/validator/src/test/java/io/avaje/validation/core/CustomerValidationAdapter.java
+++ b/validator/src/test/java/io/avaje/validation/core/CustomerValidationAdapter.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Map;
 
 import io.avaje.validation.Validator;
-import io.avaje.validation.adapter.CoreValidation;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidationRequest;
 import jakarta.validation.constraints.AssertTrue;
@@ -20,13 +19,10 @@ public final class CustomerValidationAdapter implements ValidationAdapter<Custom
   private final ValidationAdapter<Object> activeDateAdapter;
   private final ValidationAdapter<List<Contact>> contactsValidator;
 
-  private final CoreValidation core;
-
   private final ValidationAdapter<Address> addressValidator;
   private final ValidationAdapter<Contact> contactValidator;
 
   public CustomerValidationAdapter(Validator validator) {
-    this.core = validator.core();
     this.activeAdapter =
         validator.<Boolean>annotationAdapter(AssertTrue.class, Map.of("message", "not true"));
 

--- a/validator/src/test/java/io/avaje/validation/core/CustomerValidationAdapter.java
+++ b/validator/src/test/java/io/avaje/validation/core/CustomerValidationAdapter.java
@@ -3,20 +3,22 @@ package io.avaje.validation.core;
 import java.util.List;
 import java.util.Map;
 
+import io.avaje.validation.Validator;
 import io.avaje.validation.adapter.CoreValidation;
 import io.avaje.validation.adapter.ValidationAdapter;
-import io.avaje.validation.Validator;
 import io.avaje.validation.adapter.ValidationRequest;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Size;
 
 public final class CustomerValidationAdapter implements ValidationAdapter<Customer> {
 
   private final ValidationAdapter<Boolean> activeAdapter;
   private final ValidationAdapter<String> nameAdapter;
   private final ValidationAdapter<Object> activeDateAdapter;
+  private final ValidationAdapter<List<Contact>> contactsValidator;
 
   private final CoreValidation core;
 
@@ -26,17 +28,19 @@ public final class CustomerValidationAdapter implements ValidationAdapter<Custom
   public CustomerValidationAdapter(Validator validator) {
     this.core = validator.core();
     this.activeAdapter =
-        validator.<Boolean>annotationAdapter(AssertTrue.class).init(Map.of("message", "not true"));
+        validator.<Boolean>annotationAdapter(AssertTrue.class, Map.of("message", "not true"));
 
     this.nameAdapter =
         validator
-            .<String>annotationAdapter(NotNull.class)
-            .init(Map.of("message", "null"))
-            .andThen(
-                validator.<String>annotationAdapter(NotBlank.class).init(Map.of("message", "empty")));
+            .<String>annotationAdapter(NotNull.class, Map.of("message", "null"))
+            .andThen(validator.annotationAdapter(NotBlank.class, Map.of("message", "empty")));
 
     this.activeDateAdapter =
-        validator.annotationAdapter(Past.class).init(Map.of("message", "not in the past"));
+        validator.annotationAdapter(Past.class, Map.of("message", "not in the past"));
+
+    this.contactsValidator =
+        validator.<List<Contact>>annotationAdapter(
+            Size.class, Map.of("message", "not sized correctly", "min", "0", "max", "2"));
 
     addressValidator = validator.adapter(Address.class);
     contactValidator = validator.adapter(Contact.class);
@@ -59,7 +63,7 @@ public final class CustomerValidationAdapter implements ValidationAdapter<Custom
     }
 
     final var _contacts = value.contacts;
-    if (core.collection(request, "contacts", _contacts, 0, 2)) {
+    if (contactsValidator.validate(_contacts, request, "contacts")) {
       contactValidator.validateAll(_contacts, request, "contacts");
     }
     return true;


### PR DESCRIPTION
- remove the core validation collection method (using the size adapter is preferable)
- move validation initialization outside of generated adapter
- annotation attribute map is now string object (for array values and other stuff)