### PR TITLE
Move the adapter builder methods onto new AdapterBuildContext interface (in the adapter package)

### DIFF
--- a/validator/src/main/java/io/avaje/validation/Validator.java
+++ b/validator/src/main/java/io/avaje/validation/Validator.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.ServiceLoader;
 
+import io.avaje.validation.adapter.AdapterBuildContext;
 import io.avaje.validation.adapter.AnnotationValidationAdapter;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidatorComponent;
@@ -24,12 +25,6 @@ public interface Validator {
     return DefaultBootstrap.builder();
   }
 
-
-  <T> ValidationAdapter<T> adapter(Class<T> cls);
-
-  <T> ValidationAdapter<T> adapter(Type type);
-
-  <T> AnnotationValidationAdapter<T> adapter(Class<? extends Annotation> cls, Map<String, Object> attributes);
 
   /** Build the Validator instance adding ValidationAdapter, Factory or AdapterBuilder. */
   interface Builder {
@@ -63,7 +58,7 @@ public interface Validator {
   interface AdapterBuilder {
 
     /** Create a ValidationAdapter given the Validator instance. */
-    ValidationAdapter<?> build(Validator jsonb);
+    ValidationAdapter<?> build(AdapterBuildContext ctx);
   }
 
   /** Components register JsonAdapters Validator.Builder */

--- a/validator/src/main/java/io/avaje/validation/adapter/AdapterBuildContext.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/AdapterBuildContext.java
@@ -1,0 +1,15 @@
+package io.avaje.validation.adapter;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+public interface AdapterBuildContext {
+
+    <T> ValidationAdapter<T> adapter(Class<T> cls);
+
+    <T> ValidationAdapter<T> adapter(Type type);
+
+    <T> AnnotationValidationAdapter<T> adapter(Class<? extends Annotation> cls, Map<String, Object> attributes);
+
+}

--- a/validator/src/main/java/io/avaje/validation/adapter/ValidationAdapter.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/ValidationAdapter.java
@@ -56,13 +56,13 @@ public interface ValidationAdapter<T> {
   }
 
   /** Factory for creating a ValidationAdapter. */
-  public interface Factory {
+  interface Factory {
 
     /**
      * Create and return a ValidationAdapter given the type and annotations or return null.
      *
      * <p>Returning null means that the adapter could be created by another factory.
      */
-    ValidationAdapter<?> create(Type type, Validator jsonb);
+    ValidationAdapter<?> create(Type type, AdapterBuildContext ctx);
   }
 }

--- a/validator/src/main/java/io/avaje/validation/core/DValidator.java
+++ b/validator/src/main/java/io/avaje/validation/core/DValidator.java
@@ -14,13 +14,14 @@ import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 
 import io.avaje.validation.Validator;
+import io.avaje.validation.adapter.AdapterBuildContext;
 import io.avaje.validation.adapter.AnnotationValidationAdapter;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidatorComponent;
 import io.avaje.validation.adapter.AnnotationValidationAdapter.Factory;
 
 /** Default implementation of Validator. */
-final class DValidator implements Validator {
+final class DValidator implements Validator, AdapterBuildContext {
 
   private final CoreAdapterBuilder builder;
   private final Map<Type, DValidationType<?>> typeCache = new ConcurrentHashMap<>();
@@ -162,7 +163,7 @@ final class DValidator implements Validator {
     static <T> ValidationAdapter.Factory newAdapterFactory(Type type, AdapterBuilder builder) {
       requireNonNull(type);
       requireNonNull(builder);
-      return (targetType, jsonb) -> simpleMatch(type, targetType) ? builder.build(jsonb) : null;
+      return (targetType, ctx) -> simpleMatch(type, targetType) ? builder.build(ctx) : null;
     }
   }
 

--- a/validator/src/test/java/io/avaje/validation/core/AddressValidationAdapter.java
+++ b/validator/src/test/java/io/avaje/validation/core/AddressValidationAdapter.java
@@ -3,6 +3,7 @@ package io.avaje.validation.core;
 import java.util.Map;
 
 import io.avaje.validation.Validator;
+import io.avaje.validation.adapter.AdapterBuildContext;
 import io.avaje.validation.adapter.AnnotationValidationAdapter;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidationRequest;
@@ -15,7 +16,7 @@ public final class AddressValidationAdapter implements ValidationAdapter<Address
 //  private final AnnotationValidationAdapter<String> line2Adapter;
 //  private final AnnotationValidationAdapter<Long> longValueAdapter;
 
-  public AddressValidationAdapter(Validator validator) {
+  public AddressValidationAdapter(AdapterBuildContext validator) {
     this.line1Adapter =
         validator
             .<String>adapter(NotNull.class, Map.of("message", "null"))

--- a/validator/src/test/java/io/avaje/validation/core/ContactValidationAdapter.java
+++ b/validator/src/test/java/io/avaje/validation/core/ContactValidationAdapter.java
@@ -3,6 +3,7 @@ package io.avaje.validation.core;
 import java.util.Map;
 
 import io.avaje.validation.Validator;
+import io.avaje.validation.adapter.AdapterBuildContext;
 import io.avaje.validation.adapter.AnnotationValidationAdapter;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidationRequest;
@@ -15,7 +16,7 @@ public final class ContactValidationAdapter implements ValidationAdapter<Contact
   private final AnnotationValidationAdapter<String> lastNameAdapter;
   private final ValidationAdapter<Address> addressValidator;
 
-  public ContactValidationAdapter(Validator validator) {
+  public ContactValidationAdapter(AdapterBuildContext validator) {
     this.firstNameAdapter =
         validator
             .<String>adapter(NotNull.class, Map.of("message", "null"))

--- a/validator/src/test/java/io/avaje/validation/core/CustomerValidationAdapter.java
+++ b/validator/src/test/java/io/avaje/validation/core/CustomerValidationAdapter.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.avaje.validation.Validator;
+import io.avaje.validation.adapter.AdapterBuildContext;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidationRequest;
 import jakarta.validation.constraints.AssertTrue;
@@ -22,7 +23,7 @@ public final class CustomerValidationAdapter implements ValidationAdapter<Custom
   private final ValidationAdapter<Address> addressValidator;
   private final ValidationAdapter<Contact> contactValidator;
 
-  public CustomerValidationAdapter(Validator validator) {
+  public CustomerValidationAdapter(AdapterBuildContext validator) {
     this.activeAdapter =
         validator.<Boolean>adapter(AssertTrue.class, Map.of("message", "not true"));
 


### PR DESCRIPTION
The theory is we are looking to hide these methods from the casual users of Validator