### PR TITLE
Add test ACustomerMessageTest (shows Size min not defaulting)

### DIFF
--- a/blackbox-test/src/test/java/example/avaje/ACustomer.java
+++ b/blackbox-test/src/test/java/example/avaje/ACustomer.java
@@ -13,13 +13,21 @@ public class ACustomer {
     @NotBlank @Size(max = 7, message = "My custom error message with max {max}")
     final String other;
 
-    public ACustomer(String name, String other) {
-        this.name = name;
-        this.other = other;
+    @Size(min = 2, max = 4)
+    final String minMax;
+
+    public ACustomer(String name, String other, String minMax) {
+      this.name = name;
+      this.other = other;
+      this.minMax = minMax;
     }
+
+    public ACustomer(String name, String other) {
+      this(name, other, "val");
+    }
+
     public ACustomer(String name) {
-        this.name = name;
-        this.other = "valid";
+      this(name, "valid");
     }
 
     public String getName() {
@@ -28,5 +36,9 @@ public class ACustomer {
 
     public String getOther() {
         return other;
+    }
+
+    public String minMax() {
+      return minMax;
     }
 }

--- a/blackbox-test/src/test/java/example/avaje/ACustomerMessageTest.java
+++ b/blackbox-test/src/test/java/example/avaje/ACustomerMessageTest.java
@@ -1,4 +1,75 @@
 package example.avaje;
 
+import io.avaje.validation.ConstraintViolation;
+import io.avaje.validation.ConstraintViolationException;
+import io.avaje.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 class ACustomerMessageTest {
+
+  final Validator validator = Validator.builder().build();
+
+  @Test
+  void valid() {
+    var cust = new ACustomer("Rob", "Other");
+    validator.validate(cust);
+  }
+
+  @Test
+  void blank() {
+    var violation = one(new ACustomer("", "Other"));
+    assertThat(violation.message()).isEqualTo("must not be blank");
+  }
+
+  @Test
+  void blankDE() {
+    var violation = one(new ACustomer("", "Other"), Locale.GERMAN);
+    assertThat(violation.message()).isEqualTo("darf nicht leer sein");
+  }
+
+  @Test
+  void sizeMax() {
+    var violation = one(new ACustomer("NameIsTooLarge", "Other"));
+    assertThat(violation.message()).isEqualTo("size must be between {min} and 5");
+  }
+
+  @Test
+  void sizeMaxDE() {
+    var violation = one(new ACustomer("NameIsTooLarge", "Other"), Locale.GERMAN);
+    assertThat(violation.message()).isEqualTo("Größe muss zwischen {min} und 5 sein");
+  }
+
+  @Test
+  void sizeMaxCustomMessage() {
+    var violation = one(new ACustomer("Valid", "OtherTooLargeForThis"));
+    assertThat(violation.message()).isEqualTo("My custom error message with max 7");
+  }
+
+  @Test
+  void sizeMaxCustomMessageDE() {
+    var violation = one(new ACustomer("Valid", "OtherTooLargeForThis"));
+    assertThat(violation.message()).isEqualTo("My custom error message with max 7");
+  }
+
+  ConstraintViolation one(Object any) {
+    return one(any, Locale.ENGLISH);
+  }
+
+  ConstraintViolation one(Object any, Locale locale) {
+    try {
+      validator.validate(any, locale);
+      fail("not expected");
+      return null;
+    } catch (ConstraintViolationException e) {
+      var violations = new ArrayList<>(e.violations());
+      assertThat(violations).hasSize(1);
+      return violations.get(0);
+    }
+  }
 }

--- a/blackbox-test/src/test/java/example/avaje/ACustomerMessageTest.java
+++ b/blackbox-test/src/test/java/example/avaje/ACustomerMessageTest.java
@@ -36,13 +36,13 @@ class ACustomerMessageTest {
   @Test
   void sizeMax() {
     var violation = one(new ACustomer("NameIsTooLarge", "Other"));
-    assertThat(violation.message()).isEqualTo("size must be between {min} and 5");
+    assertThat(violation.message()).isEqualTo("size must be between 0 and 5");
   }
 
   @Test
   void sizeMaxDE() {
     var violation = one(new ACustomer("NameIsTooLarge", "Other"), Locale.GERMAN);
-    assertThat(violation.message()).isEqualTo("Größe muss zwischen {min} und 5 sein");
+    assertThat(violation.message()).isEqualTo("Größe muss zwischen 0 und 5 sein");
   }
 
   @Test

--- a/blackbox-test/src/test/java/example/avaje/ACustomerMessageTest.java
+++ b/blackbox-test/src/test/java/example/avaje/ACustomerMessageTest.java
@@ -46,6 +46,18 @@ class ACustomerMessageTest {
   }
 
   @Test
+  void sizeMinMax() {
+    var violation = one(new ACustomer("valid", "Other", "TooLarge"));
+    assertThat(violation.message()).isEqualTo("size must be between 2 and 4");
+  }
+
+  @Test
+  void sizeMinMaxDE() {
+    var violation = one(new ACustomer("valid", "Other", "TooLarge"), Locale.GERMAN);
+    assertThat(violation.message()).isEqualTo("Größe muss zwischen 2 und 4 sein");
+  }
+
+  @Test
   void sizeMaxCustomMessage() {
     var violation = one(new ACustomer("Valid", "OtherTooLargeForThis"));
     assertThat(violation.message()).isEqualTo("My custom error message with max 7");

--- a/validator/src/main/java/io/avaje/validation/core/adapters/BasicAdapters.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/BasicAdapters.java
@@ -1,10 +1,7 @@
 package io.avaje.validation.core.adapters;
 
 import java.lang.reflect.Array;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -30,9 +27,17 @@ public final class BasicAdapters {
       case "Future" -> new FuturePastAdapter(context.message("Future", attributes), false, false);
       case "FutureOrPresent" -> new FuturePastAdapter(context.message("FutureOrPresent", attributes), false, true);
       case "Pattern" -> new PatternAdapter(context.message2("{avaje.Pattern.message}", attributes), attributes);
-      case "Size" -> new SizeAdapter(context.message2("{avaje.Size.message}", attributes), attributes);
+      case "Size" -> createSize(context, attributes);
       default -> null;
     };
+
+  private static ValidationAdapter<?> createSize(ValidationContext context, Map<String, Object> attributes) {
+    if (!attributes.containsKey("min")) {
+      attributes = new LinkedHashMap<>(attributes);
+      attributes.put("min", 0);
+    }
+    return new SizeAdapter(context.message2("{avaje.Size.message}", attributes), attributes);
+  }
 
   private static final class PatternAdapter implements ValidationAdapter<CharSequence> {
 


### PR DESCRIPTION
Size min expected to default to 0 according to the error messages we have.

So given:
```java
    @NotBlank @Size(max = 5)
    final String name;
```

Generates:
```java
    this.nameValidationAdapter = 
        ctx.<String>adapter(Size.class, Map.of("max",5))
            .andThen(ctx.adapter(NotBlank.class,Map.of()));
```

And we can get the validation message where the {min} is not replaced (with say 0 or indeed 1):

```
size must be between {min} and 5
```

The default value for Size min is 0, so we reasonably expect the `{min}` to be replaced by `0`.  

I note that we know in this case that there is also the `@NotBlank` and technically that means that the Size min should really be 1 (because we know with the NotBlank that 0 isn't a valid minimum number of chars).

Perhaps ... we could ensure the ordering such that `NotBlank, NotEmpty, NotNull` are higher precedence and the generated code always puts those first and IF that happened and the context knew that a NotBlank proceeded the Size THEN ... it could deduce that the default min should be 1.

Regardless it looks like the way SizeAdapter is created needs adjustment to allow for the min defaulting to 0. 
