### PR TITLE
Fix Boolean Nulls/Refactor Time Adapters/Adapter Tests

### DIFF
--- a/validator/src/main/java/io/avaje/validation/Validator.java
+++ b/validator/src/main/java/io/avaje/validation/Validator.java
@@ -6,11 +6,13 @@ import io.avaje.validation.spi.Bootstrap;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.Iterator;
+import java.time.Clock;
+import java.time.Duration;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.ServiceLoader;
+import java.util.function.Supplier;
 
 public interface Validator {
 
@@ -27,7 +29,7 @@ public interface Validator {
   void validate(Object any, Locale locale) throws ConstraintViolationException;
 
   static Builder builder() {
-    final Iterator<Bootstrap> bootstrapService = ServiceLoader.load(Bootstrap.class).iterator();
+    final var bootstrapService = ServiceLoader.load(Bootstrap.class).iterator();
     if (bootstrapService.hasNext()) {
       return bootstrapService.next().builder();
     }
@@ -60,6 +62,10 @@ public interface Validator {
 
     /** Adds additional Locales for this validator */
     Builder addLocales(Locale... locales);
+
+    Builder clockProvider(Supplier<Clock> clockSupplier);
+
+    Builder temporalTolerance(Duration temporalTolerance);
 
     /** Add a AdapterBuilder which provides a ValidationAdapter to use for the given type. */
     Builder add(Type type, AdapterBuilder builder);

--- a/validator/src/main/java/io/avaje/validation/core/CoreAdapterBuilder.java
+++ b/validator/src/main/java/io/avaje/validation/core/CoreAdapterBuilder.java
@@ -27,7 +27,9 @@ final class CoreAdapterBuilder {
   CoreAdapterBuilder(
       DValidator context,
       List<ValidationContext.AdapterFactory> userFactories,
-      List<ValidationContext.AnnotationFactory> userAnnotationFactories, Supplier<Clock> clockSupplier, Duration temporalTolerance) {
+      List<ValidationContext.AnnotationFactory> userAnnotationFactories,
+      Supplier<Clock> clockSupplier,
+      Duration temporalTolerance) {
     this.context = context;
     this.factories.addAll(userFactories);
     this.annotationFactories.addAll(userAnnotationFactories);
@@ -63,6 +65,8 @@ final class CoreAdapterBuilder {
       }
     }
     throw new IllegalArgumentException("No ValidationAdapter for " + type + ". Perhaps needs @ValidPojo or @ValidPojo.Import?");
+    throw new IllegalArgumentException(
+        "No ValidationAdapter for " + type + ". Perhaps needs @ValidPojo or @ValidPojo.Import?");
   }
 
   /** Build given type and annotations. */

--- a/validator/src/main/java/io/avaje/validation/core/CoreAdapterBuilder.java
+++ b/validator/src/main/java/io/avaje/validation/core/CoreAdapterBuilder.java
@@ -65,8 +65,6 @@ final class CoreAdapterBuilder {
       }
     }
     throw new IllegalArgumentException("No ValidationAdapter for " + type + ". Perhaps needs @ValidPojo or @ValidPojo.Import?");
-    throw new IllegalArgumentException(
-        "No ValidationAdapter for " + type + ". Perhaps needs @ValidPojo or @ValidPojo.Import?");
   }
 
   /** Build given type and annotations. */

--- a/validator/src/main/java/io/avaje/validation/core/CoreAdapterBuilder.java
+++ b/validator/src/main/java/io/avaje/validation/core/CoreAdapterBuilder.java
@@ -2,14 +2,18 @@ package io.avaje.validation.core;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.time.Clock;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidationContext;
 import io.avaje.validation.core.adapters.BasicAdapters;
+import io.avaje.validation.core.adapters.FuturePastAdapterFactory;
 import io.avaje.validation.core.adapters.NumberAdapters;
 
 /** Builds and caches the ValidationAdapter adapters for DValidator. */
@@ -23,12 +27,13 @@ final class CoreAdapterBuilder {
   CoreAdapterBuilder(
       DValidator context,
       List<ValidationContext.AdapterFactory> userFactories,
-      List<ValidationContext.AnnotationFactory> userAnnotationFactories) {
+      List<ValidationContext.AnnotationFactory> userAnnotationFactories, Supplier<Clock> clockSupplier, Duration temporalTolerance) {
     this.context = context;
     this.factories.addAll(userFactories);
     this.annotationFactories.addAll(userAnnotationFactories);
     this.annotationFactories.add(BasicAdapters.FACTORY);
     this.annotationFactories.add(NumberAdapters.FACTORY);
+    this.annotationFactories.add(new FuturePastAdapterFactory(clockSupplier, temporalTolerance));
   }
 
   /** Return the adapter from cache if exists else return null. */
@@ -52,7 +57,7 @@ final class CoreAdapterBuilder {
   <T> ValidationAdapter<T> build(Type type, Object cacheKey) {
     // Ask each factory to create the validation adapter.
     for (final ValidationContext.AdapterFactory factory : factories) {
-      final ValidationAdapter<T> result = (ValidationAdapter<T>) factory.create(type, context);
+      final var result = (ValidationAdapter<T>) factory.create(type, context);
       if (result != null) {
         return result;
       }

--- a/validator/src/main/java/io/avaje/validation/core/DValidator.java
+++ b/validator/src/main/java/io/avaje/validation/core/DValidator.java
@@ -7,15 +7,17 @@ import static java.util.Objects.requireNonNull;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.time.Clock;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 import io.avaje.lang.Nullable;
 import io.avaje.validation.Validator;
@@ -40,12 +42,13 @@ final class DValidator implements Validator, ValidationContext {
       List<String> bundleNames,
       List<ResourceBundle> bundles,
       MessageInterpolator interpolator,
-      LocaleResolver localeResolver) {
+      LocaleResolver localeResolver,
+      Supplier<Clock> clockSupplier,Duration temporalTolerance) {
     this.localeResolver = localeResolver;
     final var defaultResourceBundle = new DResourceBundleManager(bundleNames, bundles, localeResolver);
     this.templateLookup = new DTemplateLookup(defaultResourceBundle);
     this.interpolator = interpolator;
-    this.builder = new CoreAdapterBuilder(this, factories, annotationFactories);
+    this.builder = new CoreAdapterBuilder(this, factories, annotationFactories, clockSupplier, temporalTolerance);
   }
 
   MessageInterpolator interpolator() {
@@ -138,6 +141,8 @@ final class DValidator implements Validator, ValidationContext {
     private final List<ResourceBundle> bundles = new ArrayList<>();
     private final List<Locale> otherLocals = new ArrayList<>();
     private Locale defaultLocal = Locale.getDefault();
+    private Supplier<Clock> clockSupplier = Clock::systemDefaultZone;
+    private Duration temporalTolerance = Duration.ZERO;
 
     @Override
     public Builder add(Type type, AdapterBuilder builder) {
@@ -201,6 +206,18 @@ final class DValidator implements Validator, ValidationContext {
       return this;
     }
 
+    @Override
+    public Builder clockProvider(Supplier<Clock> clockSupplier) {
+      this.clockSupplier = clockSupplier;
+      return this;
+    }
+
+    @Override
+    public Builder temporalTolerance(Duration temporalTolerance) {
+      this.temporalTolerance = temporalTolerance;
+      return this;
+    }
+
     private void registerComponents() {
       // first register all user defined ValidatorComponent
       for (final ValidatorComponent next : ServiceLoader.load(ValidatorComponent.class)) {
@@ -220,7 +237,7 @@ final class DValidator implements Validator, ValidationContext {
           ServiceLoader.load(MessageInterpolator.class)
               .findFirst()
               .orElseGet(BasicMessageInterpolator::new);
-      return new DValidator(factories, afactories, bundleNames, bundles, interpolator, localeResolver);
+      return new DValidator(factories, afactories, bundleNames, bundles, interpolator, localeResolver, clockSupplier, temporalTolerance);
     }
 
     private static <T> AnnotationFactory newAnnotationAdapterFactory(Type type, ValidationAdapter<T> adapter) {

--- a/validator/src/main/java/io/avaje/validation/core/DValidator.java
+++ b/validator/src/main/java/io/avaje/validation/core/DValidator.java
@@ -43,12 +43,16 @@ final class DValidator implements Validator, ValidationContext {
       List<ResourceBundle> bundles,
       MessageInterpolator interpolator,
       LocaleResolver localeResolver,
-      Supplier<Clock> clockSupplier,Duration temporalTolerance) {
+      Supplier<Clock> clockSupplier,
+      Duration temporalTolerance) {
     this.localeResolver = localeResolver;
-    final var defaultResourceBundle = new DResourceBundleManager(bundleNames, bundles, localeResolver);
+    final var defaultResourceBundle =
+        new DResourceBundleManager(bundleNames, bundles, localeResolver);
     this.templateLookup = new DTemplateLookup(defaultResourceBundle);
     this.interpolator = interpolator;
-    this.builder = new CoreAdapterBuilder(this, factories, annotationFactories, clockSupplier, temporalTolerance);
+    this.builder =
+        new CoreAdapterBuilder(
+            this, factories, annotationFactories, clockSupplier, temporalTolerance);
   }
 
   MessageInterpolator interpolator() {
@@ -237,7 +241,15 @@ final class DValidator implements Validator, ValidationContext {
           ServiceLoader.load(MessageInterpolator.class)
               .findFirst()
               .orElseGet(BasicMessageInterpolator::new);
-      return new DValidator(factories, afactories, bundleNames, bundles, interpolator, localeResolver, clockSupplier, temporalTolerance);
+      return new DValidator(
+          factories,
+          afactories,
+          bundleNames,
+          bundles,
+          interpolator,
+          localeResolver,
+          clockSupplier,
+          temporalTolerance);
     }
 
     private static <T> AnnotationFactory newAnnotationAdapterFactory(Type type, ValidationAdapter<T> adapter) {

--- a/validator/src/main/java/io/avaje/validation/core/adapters/BasicAdapters.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/BasicAdapters.java
@@ -15,23 +15,27 @@ import io.avaje.validation.adapter.ValidationRequest;
 public final class BasicAdapters {
   private BasicAdapters() {}
 
-  public static final ValidationContext.AnnotationFactory FACTORY = (annotationType, context, attributes) ->
-    switch (annotationType.getSimpleName()) {
-        case "Email" -> new EmailAdapter(context.message(attributes), attributes);
-        case "Null" -> new NullableAdapter(context.message(attributes), true);
-        case "NotNull", "NonNull" -> new NullableAdapter(context.message(attributes), false);
-        case "AssertTrue" -> new AssertBooleanAdapter(context.message(attributes), Boolean.FALSE);
-        case "AssertFalse" -> new AssertBooleanAdapter(context.message(attributes), Boolean.TRUE);
-        case "NotBlank" -> new NotBlankAdapter(context.message(attributes));
-        case "NotEmpty" -> new NotEmptyAdapter(context.message(attributes));
-        case "Past" -> new FuturePastAdapter(context.message(attributes), true, false);
-        case "PastOrPresent" -> new FuturePastAdapter(context.message(attributes), true, true);
-        case "Future" -> new FuturePastAdapter(context.message(attributes), false, false);
-        case "FutureOrPresent" -> new FuturePastAdapter(context.message(attributes), false, true);
-        case "Pattern" -> new PatternAdapter(context.message(attributes), attributes);
-        case "Size" -> new SizeAdapter(context.message(attributes), attributes);
-        default -> null;
-      };
+  public static final ValidationContext.AnnotationFactory FACTORY =
+      (annotationType, context, attributes) ->
+          switch (annotationType.getSimpleName()) {
+            case "Email" -> new EmailAdapter(context.message(attributes), attributes);
+            case "Null" -> new NullableAdapter(context.message(attributes), true);
+            case "NotNull", "NonNull" -> new NullableAdapter(context.message(attributes), false);
+            case "AssertTrue" -> new AssertBooleanAdapter(
+                context.message(attributes), Boolean.TRUE);
+            case "AssertFalse" -> new AssertBooleanAdapter(
+                context.message(attributes), Boolean.FALSE);
+            case "NotBlank" -> new NotBlankAdapter(context.message(attributes));
+            case "NotEmpty" -> new NotEmptyAdapter(context.message(attributes));
+            case "Past" -> new FuturePastAdapter(context.message(attributes), true, false);
+            case "PastOrPresent" -> new FuturePastAdapter(context.message(attributes), true, true);
+            case "Future" -> new FuturePastAdapter(context.message(attributes), false, false);
+            case "FutureOrPresent" -> new FuturePastAdapter(
+                context.message(attributes), false, true);
+            case "Pattern" -> new PatternAdapter(context.message(attributes), attributes);
+            case "Size" -> new SizeAdapter(context.message(attributes), attributes);
+            default -> null;
+          };
 
   private static final class PatternAdapter implements ValidationAdapter<CharSequence> {
 
@@ -193,7 +197,11 @@ public final class BasicAdapters {
 
     @Override
     public boolean validate(Boolean type, ValidationRequest req, String propertyName) {
-      if (assertBool.equals(type)) {
+      if (!assertBool.booleanValue() && type == null) {
+        return true;
+      }
+
+      if (!assertBool.equals(type)) {
         req.addViolation(message, propertyName);
         return false;
       }

--- a/validator/src/main/java/io/avaje/validation/core/adapters/BasicAdapters.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/BasicAdapters.java
@@ -21,17 +21,10 @@ public final class BasicAdapters {
             case "Email" -> new EmailAdapter(context.message(attributes), attributes);
             case "Null" -> new NullableAdapter(context.message(attributes), true);
             case "NotNull", "NonNull" -> new NullableAdapter(context.message(attributes), false);
-            case "AssertTrue" -> new AssertBooleanAdapter(
-                context.message(attributes), Boolean.TRUE);
-            case "AssertFalse" -> new AssertBooleanAdapter(
-                context.message(attributes), Boolean.FALSE);
+            case "AssertTrue" -> new AssertBooleanAdapter(context.message(attributes), Boolean.TRUE);
+            case "AssertFalse" -> new AssertBooleanAdapter(context.message(attributes), Boolean.FALSE);
             case "NotBlank" -> new NotBlankAdapter(context.message(attributes));
             case "NotEmpty" -> new NotEmptyAdapter(context.message(attributes));
-            case "Past" -> new FuturePastAdapter(context.message(attributes), true, false);
-            case "PastOrPresent" -> new FuturePastAdapter(context.message(attributes), true, true);
-            case "Future" -> new FuturePastAdapter(context.message(attributes), false, false);
-            case "FutureOrPresent" -> new FuturePastAdapter(
-                context.message(attributes), false, true);
             case "Pattern" -> new PatternAdapter(context.message(attributes), attributes);
             case "Size" -> new SizeAdapter(context.message(attributes), attributes);
             default -> null;

--- a/validator/src/main/java/io/avaje/validation/core/adapters/BasicAdapters.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/BasicAdapters.java
@@ -51,7 +51,11 @@ public final class BasicAdapters {
 
     @Override
     public boolean validate(CharSequence value, ValidationRequest req, String propertyName) {
-      if (value == null || pattern.test(value.toString())) {
+      if (value == null) {
+        return true;
+      }
+
+      if (pattern.test(value.toString())) {
         req.addViolation(message, propertyName);
         return false;
       }

--- a/validator/src/main/java/io/avaje/validation/core/adapters/BasicAdapters.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/BasicAdapters.java
@@ -1,6 +1,5 @@
 package io.avaje.validation.core.adapters;
 
-import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -100,7 +99,7 @@ public final class BasicAdapters {
           return len > 0;
         }
       } else if (value.getClass().isArray()) {
-        final var len = Array.getLength(value);
+        final var len = arrayLength(value);
         if (len > max || len < min) {
           req.addViolation(message, propertyName);
           return len > 0;
@@ -171,7 +170,7 @@ public final class BasicAdapters {
           return false;
         }
       } else if (value.getClass().isArray()) {
-        final var len = Array.getLength(value);
+        final var len = arrayLength(value);
         if (len == 0) {
           req.addViolation(message, propertyName);
           return false;
@@ -223,6 +222,29 @@ public final class BasicAdapters {
         return false;
       }
       return true;
+    }
+  }
+
+  private static int arrayLength(Object array) {
+
+    if (array instanceof int[] arr) {
+      return arr.length;
+    } else if (array instanceof boolean[] arr) {
+      return arr.length;
+    } else if (array instanceof byte[] arr) {
+      return arr.length;
+    } else if (array instanceof char[] arr) {
+      return arr.length;
+    } else if (array instanceof short[] arr) {
+      return arr.length;
+    } else if (array instanceof float[] arr) {
+      return arr.length;
+    } else if (array instanceof double[] arr) {
+      return arr.length;
+    } else if (array instanceof long[] arr) {
+      return arr.length;
+    } else {
+      return ((Object[]) array).length;
     }
   }
 }

--- a/validator/src/main/java/io/avaje/validation/core/adapters/FuturePastAdapter.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/FuturePastAdapter.java
@@ -91,19 +91,19 @@ final class FuturePastAdapter implements ValidationAdapter<Object> {
   private boolean compare(OffsetDateTime instant) {
     Predicate<OffsetDateTime> predicate = past ? instant::isBefore : instant::isAfter;
     predicate = includePresent ? predicate.or(instant::equals) : predicate;
-    return predicate.test(OffsetDateTime.now());
+    return predicate.negate().test(OffsetDateTime.now());
   }
 
   private boolean compare(OffsetTime instant) {
     Predicate<OffsetTime> predicate = past ? instant::isBefore : instant::isAfter;
     predicate = includePresent ? predicate.or(instant::equals) : predicate;
-    return predicate.test(OffsetTime.now());
+    return predicate.negate().test(OffsetTime.now());
   }
 
   private boolean compare(Year instant) {
     Predicate<Year> predicate = past ? instant::isBefore : instant::isAfter;
     predicate = includePresent ? predicate.or(instant::equals) : predicate;
-    return predicate.test(Year.now());
+    return predicate.negate().test(Year.now());
   }
 
   private boolean compare(YearMonth instant) {

--- a/validator/src/main/java/io/avaje/validation/core/adapters/FuturePastAdapter.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/FuturePastAdapter.java
@@ -32,9 +32,9 @@ final class FuturePastAdapter implements ValidationAdapter<Object> {
   @Override
   public boolean validate(Object obj, ValidationRequest req, String propertyName) {
     if (obj == null) {
-      req.addViolation(message, propertyName);
-      return false;
+      return true;
     }
+
     if (obj instanceof final Date date && compare(date)
         || obj instanceof final TemporalAccessor temporalAccessor
             && (temporalAccessor instanceof final Instant ins && compare(ins)

--- a/validator/src/main/java/io/avaje/validation/core/adapters/FuturePastAdapterFactory.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/FuturePastAdapterFactory.java
@@ -1,0 +1,59 @@
+package io.avaje.validation.core.adapters;
+
+import java.lang.annotation.Annotation;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import io.avaje.validation.adapter.ValidationAdapter;
+import io.avaje.validation.adapter.ValidationContext;
+import io.avaje.validation.adapter.ValidationContext.AnnotationFactory;
+
+public final class FuturePastAdapterFactory implements AnnotationFactory {
+
+  private Clock pastClock;
+
+  private Clock futureClock;
+
+  private final Supplier<Clock> clockSupplier;
+  private final Duration tolerance;
+
+  public FuturePastAdapterFactory(Supplier<Clock> clockSupplier, Duration tolerance) {
+    this.clockSupplier = clockSupplier;
+    this.tolerance = tolerance;
+  }
+
+  @Override
+  public ValidationAdapter<?> create(
+      Class<? extends Annotation> annotationType,
+      ValidationContext context,
+      Map<String, Object> attributes) {
+    return switch (annotationType.getSimpleName()) {
+      case "Past" -> new FuturePastAdapter(context.message(attributes), true, false, pastClock());
+      case "PastOrPresent" -> new FuturePastAdapter(
+          context.message(attributes), true, true, pastClock());
+      case "Future" -> new FuturePastAdapter(
+          context.message(attributes), false, false, futureClock());
+      case "FutureOrPresent" -> new FuturePastAdapter(
+          context.message(attributes), false, true, futureClock());
+      default -> null;
+    };
+  }
+
+  private Clock pastClock() {
+
+    if (pastClock == null) {
+      pastClock = Clock.offset(clockSupplier.get(), tolerance);
+    }
+
+    return pastClock;
+  }
+
+  private Clock futureClock() {
+    if (futureClock == null) {
+      futureClock = Clock.offset(clockSupplier.get(), tolerance.negated());
+    }
+    return futureClock;
+  }
+}

--- a/validator/src/main/java/io/avaje/validation/core/adapters/NumberAdapters.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/NumberAdapters.java
@@ -92,7 +92,7 @@ public final class NumberAdapters {
 
     MaxAdapter(ValidationContext.Message message, Map<String, Object> attributes) {
       this.message = message;
-      this.value = ((Number) attributes.get("value")).longValue();
+      this.value = (long) attributes.get("value");
     }
 
     @Override
@@ -117,7 +117,7 @@ public final class NumberAdapters {
 
     MinAdapter(ValidationContext.Message message, Map<String, Object> attributes) {
       this.message = message;
-      this.value = ((Number) attributes.get("value")).longValue();
+      this.value = (long) attributes.get("value");
     }
 
     @Override

--- a/validator/src/main/java/io/avaje/validation/core/adapters/NumberAdapters.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/NumberAdapters.java
@@ -12,23 +12,22 @@ import io.avaje.validation.adapter.ValidationContext;
 import io.avaje.validation.adapter.ValidationRequest;
 
 public final class NumberAdapters {
-  private NumberAdapters() {
-  }
+  private NumberAdapters() {}
 
   public static final ValidationContext.AnnotationFactory FACTORY =
-    (annotationType, context, attributes) ->
-      switch (annotationType.getSimpleName()) {
-        case "Digits" -> new DigitsAdapter(context.message(attributes), attributes);
-        case "Positive" -> new PositiveAdapter(context.message(attributes));
-        case "PositiveOrZero" -> new PositiveAdapter(context.message(attributes), true);
-        case "Negative" -> new NegativeAdapter(context.message(attributes));
-        case "NegativeOrZero" -> new NegativeAdapter(context.message(attributes), true);
-        case "Max" -> new MaxAdapter(context.message(attributes), attributes);
-        case "Min" -> new MinAdapter(context.message(attributes), attributes);
-        case "DecimalMax" -> new DecimalMaxAdapter(context.message(attributes), attributes);
-        case "DecimalMin" -> new DecimalMinAdapter(context.message(attributes), attributes);
-        default -> null;
-      };
+      (annotationType, context, attributes) ->
+          switch (annotationType.getSimpleName()) {
+            case "Digits" -> new DigitsAdapter(context.message(attributes), attributes);
+            case "Positive" -> new PositiveAdapter(context.message(attributes));
+            case "PositiveOrZero" -> new PositiveAdapter(context.message(attributes), true);
+            case "Negative" -> new NegativeAdapter(context.message(attributes));
+            case "NegativeOrZero" -> new NegativeAdapter(context.message(attributes), true);
+            case "Max" -> new MaxAdapter(context.message(attributes), attributes);
+            case "Min" -> new MinAdapter(context.message(attributes), attributes);
+            case "DecimalMax" -> new DecimalMaxAdapter(context.message(attributes), attributes);
+            case "DecimalMin" -> new DecimalMinAdapter(context.message(attributes), attributes);
+            default -> null;
+          };
 
   private static final class DecimalMaxAdapter implements ValidationAdapter<Number> {
 
@@ -93,7 +92,7 @@ public final class NumberAdapters {
 
     MaxAdapter(ValidationContext.Message message, Map<String, Object> attributes) {
       this.message = message;
-      this.value = (long) attributes.get("value");
+      this.value = ((Number) attributes.get("value")).longValue();
     }
 
     @Override
@@ -118,7 +117,7 @@ public final class NumberAdapters {
 
     MinAdapter(ValidationContext.Message message, Map<String, Object> attributes) {
       this.message = message;
-      this.value = (long) attributes.get("value");
+      this.value = ((Number) attributes.get("value")).longValue();
     }
 
     @Override

--- a/validator/src/test/java/io/avaje/validation/core/BasicTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/BasicTest.java
@@ -5,6 +5,7 @@ import io.avaje.validation.ConstraintViolationException;
 import io.avaje.validation.Validator;
 import io.avaje.validation.adapter.ValidationContext;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Locale;
 
@@ -17,6 +18,7 @@ public abstract class BasicTest {
           .add(Address.class, AddressValidationAdapter::new)
           .add(Contact.class, ContactValidationAdapter::new)
           .addLocales(Locale.GERMAN)
+          .temporalTolerance(Duration.ofSeconds(20))
           .build();
 
   protected static final ValidationContext ctx = (ValidationContext) validator;

--- a/validator/src/test/java/io/avaje/validation/core/BasicTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/BasicTest.java
@@ -18,7 +18,7 @@ public abstract class BasicTest {
           .add(Address.class, AddressValidationAdapter::new)
           .add(Contact.class, ContactValidationAdapter::new)
           .addLocales(Locale.GERMAN)
-          .temporalTolerance(Duration.ofMillis(60000))
+          .temporalTolerance(Duration.ofMillis(20000))
           .build();
 
   protected static final ValidationContext ctx = (ValidationContext) validator;

--- a/validator/src/test/java/io/avaje/validation/core/BasicTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/BasicTest.java
@@ -3,20 +3,25 @@ package io.avaje.validation.core;
 import io.avaje.validation.ConstraintViolation;
 import io.avaje.validation.ConstraintViolationException;
 import io.avaje.validation.Validator;
+import io.avaje.validation.adapter.ValidationContext;
 
 import java.util.ArrayList;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-abstract class BasicTest {
+public abstract class BasicTest {
 
   protected static final Validator validator =
-    Validator.builder()
-      .add(Address.class, AddressValidationAdapter::new)
-      .add(Contact.class, ContactValidationAdapter::new)
-      .addLocales(Locale.GERMAN)
-      .build();
+      Validator.builder()
+          .add(Address.class, AddressValidationAdapter::new)
+          .add(Contact.class, ContactValidationAdapter::new)
+          .addLocales(Locale.GERMAN)
+          .build();
+
+  protected static final ValidationContext ctx = (ValidationContext) validator;
+
+  protected static final DRequest request = new DRequest((DValidator) validator, null);
 
   protected ConstraintViolation one(Object pojo, Locale locale) {
     try {

--- a/validator/src/test/java/io/avaje/validation/core/BasicTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/BasicTest.java
@@ -18,7 +18,7 @@ public abstract class BasicTest {
           .add(Address.class, AddressValidationAdapter::new)
           .add(Contact.class, ContactValidationAdapter::new)
           .addLocales(Locale.GERMAN)
-          .temporalTolerance(Duration.ofSeconds(20))
+          .temporalTolerance(Duration.ofMillis(60000))
           .build();
 
   protected static final ValidationContext ctx = (ValidationContext) validator;

--- a/validator/src/test/java/io/avaje/validation/core/BasicTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/BasicTest.java
@@ -18,7 +18,7 @@ public abstract class BasicTest {
           .add(Address.class, AddressValidationAdapter::new)
           .add(Contact.class, ContactValidationAdapter::new)
           .addLocales(Locale.GERMAN)
-          .temporalTolerance(Duration.ofMillis(20000))
+          .temporalTolerance(Duration.ofSeconds(20))
           .build();
 
   protected static final ValidationContext ctx = (ValidationContext) validator;

--- a/validator/src/test/java/io/avaje/validation/core/adapters/AssertBooleanTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/AssertBooleanTest.java
@@ -1,0 +1,43 @@
+package io.avaje.validation.core.adapters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.adapter.ValidationAdapter;
+import io.avaje.validation.adapter.ValidationContext;
+import io.avaje.validation.core.BasicTest;
+
+class AssertBooleanTest extends BasicTest {
+
+  static final ValidationContext ctx = (ValidationContext) validator;
+
+  @interface AssertTrue {}
+
+  @interface AssertFalse {}
+
+  ValidationAdapter<Object> trueAdapter =
+      ctx.adapter(AssertTrue.class, Map.of("message", "This sentence"));
+  ValidationAdapter<Object> falseAdapter =
+      ctx.adapter(AssertFalse.class, Map.of("message", "is false"));
+
+  @Test
+  void testNull() {
+    assertThat(trueAdapter.validate(null, request)).isFalse();
+    assertThat(falseAdapter.validate(null, request)).isTrue();
+  }
+
+  @Test
+  void testTrue() {
+    assertThat(trueAdapter.validate(true, request)).isTrue();
+    assertThat(falseAdapter.validate(true, request)).isFalse();
+  }
+
+  @Test
+  void testFalse() {
+    assertThat(trueAdapter.validate(false, request)).isFalse();
+    assertThat(falseAdapter.validate(false, request)).isTrue();
+  }
+}

--- a/validator/src/test/java/io/avaje/validation/core/adapters/DecimalMinMaxTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/DecimalMinMaxTest.java
@@ -1,0 +1,80 @@
+package io.avaje.validation.core.adapters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.adapter.ValidationAdapter;
+import io.avaje.validation.core.BasicTest;
+
+class DecimalMinMaxTest extends BasicTest {
+
+  @interface DecimalMin {}
+
+  @interface DecimalMax {}
+
+  ValidationAdapter<Object> minAdapter =
+      ctx.adapter(DecimalMin.class, Map.of("message", "mini", "value", "-69"));
+
+  ValidationAdapter<Object> maxAdapter =
+      ctx.adapter(DecimalMax.class, Map.of("message", "maxwell", "value", "69"));
+
+  @Test
+  void testNull() {
+    assertThat(minAdapter.validate(null, request)).isTrue();
+    assertThat(maxAdapter.validate(null, request)).isTrue();
+  }
+
+  @Test
+  void testMax() {
+
+    assertThat(maxAdapter.validate(0, request)).isTrue();
+    assertThat(maxAdapter.validate(0f, request)).isTrue();
+    assertThat(maxAdapter.validate(0D, request)).isTrue();
+    assertThat(maxAdapter.validate(0L, request)).isTrue();
+    assertThat(maxAdapter.validate((short) 0, request)).isTrue();
+    assertThat(maxAdapter.validate((byte) 0, request)).isTrue();
+    assertThat(maxAdapter.validate(BigInteger.valueOf(0), request)).isTrue();
+    assertThat(maxAdapter.validate(BigDecimal.valueOf(0), request)).isTrue();
+  }
+
+  @Test
+  void testMin() {
+    assertThat(minAdapter.validate(-0, request)).isTrue();
+    assertThat(minAdapter.validate(-0f, request)).isTrue();
+    assertThat(minAdapter.validate(-0D, request)).isTrue();
+    assertThat(minAdapter.validate(-0L, request)).isTrue();
+    assertThat(minAdapter.validate((short) -0, request)).isTrue();
+    assertThat(minAdapter.validate((byte) -0, request)).isTrue();
+    assertThat(minAdapter.validate(BigInteger.valueOf(-0), request)).isTrue();
+    assertThat(minAdapter.validate(BigDecimal.valueOf(-0), request)).isTrue();
+  }
+
+  @Test
+  void testMaxInValid() {
+    assertThat(maxAdapter.validate(01234, request)).isFalse();
+    assertThat(maxAdapter.validate(01234f, request)).isFalse();
+    assertThat(maxAdapter.validate(01234D, request)).isFalse();
+    assertThat(maxAdapter.validate(01234L, request)).isFalse();
+    assertThat(maxAdapter.validate((short) 01234, request)).isFalse();
+    assertThat(maxAdapter.validate((byte) 01234567, request)).isFalse();
+    assertThat(maxAdapter.validate(BigInteger.valueOf(01234), request)).isFalse();
+    assertThat(maxAdapter.validate(BigDecimal.valueOf(01234), request)).isFalse();
+  }
+
+  @Test
+  void testMinInValid() {
+    assertThat(minAdapter.validate(-01234, request)).isFalse();
+    assertThat(minAdapter.validate(-01234f, request)).isFalse();
+    assertThat(minAdapter.validate(-01234D, request)).isFalse();
+    assertThat(minAdapter.validate(-01234L, request)).isFalse();
+    assertThat(minAdapter.validate((short) -01234, request)).isFalse();
+    assertThat(minAdapter.validate((byte) -01234567, request)).isFalse();
+    assertThat(minAdapter.validate(BigInteger.valueOf(-01234), request)).isFalse();
+    assertThat(minAdapter.validate(BigDecimal.valueOf(-01234), request)).isFalse();
+  }
+}

--- a/validator/src/test/java/io/avaje/validation/core/adapters/DigitsTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/DigitsTest.java
@@ -1,0 +1,56 @@
+package io.avaje.validation.core.adapters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.adapter.ValidationAdapter;
+import io.avaje.validation.core.BasicTest;
+
+class DigitsTest extends BasicTest {
+
+  @interface Digits {}
+
+  ValidationAdapter<Object> digitAdapter =
+      ctx.adapter(Digits.class, Map.of("message", "digimon", "integer", 5, "fraction", 5));
+
+  @Test
+  void testNull() {
+    assertThat(digitAdapter.validate(null, request)).isTrue();
+  }
+
+  @Test
+  void testValid() {
+    assertThat(digitAdapter.validate(0, request)).isTrue();
+    assertThat(digitAdapter.validate(0f, request)).isTrue();
+    assertThat(digitAdapter.validate(0D, request)).isTrue();
+    assertThat(digitAdapter.validate(0L, request)).isTrue();
+    assertThat(digitAdapter.validate((short) 0, request)).isTrue();
+    assertThat(digitAdapter.validate((byte) 0, request)).isTrue();
+    assertThat(digitAdapter.validate(BigInteger.ZERO, request)).isTrue();
+    assertThat(digitAdapter.validate(BigDecimal.ZERO, request)).isTrue();
+  }
+
+  @Test
+  void testInValid() {
+    assertThat(digitAdapter.validate(01234, request)).isTrue();
+    assertThat(digitAdapter.validate(01234f, request)).isTrue();
+    assertThat(digitAdapter.validate(01234D, request)).isTrue();
+    assertThat(digitAdapter.validate(01234L, request)).isTrue();
+    assertThat(digitAdapter.validate((short) 01234, request)).isTrue();
+    assertThat(digitAdapter.validate((byte) 01234, request)).isTrue();
+    assertThat(digitAdapter.validate(BigInteger.valueOf(01234), request)).isTrue();
+    assertThat(digitAdapter.validate(BigDecimal.valueOf(01234), request)).isTrue();
+  }
+
+  @Test
+  void testInValidFraction() {
+    assertThat(digitAdapter.validate(0.12345f, request)).isTrue();
+    assertThat(digitAdapter.validate(0.12345D, request)).isTrue();
+    assertThat(digitAdapter.validate(BigDecimal.valueOf(0.12345), request)).isTrue();
+  }
+}

--- a/validator/src/test/java/io/avaje/validation/core/adapters/EmailTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/EmailTest.java
@@ -1,0 +1,41 @@
+package io.avaje.validation.core.adapters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.adapter.ValidationAdapter;
+import io.avaje.validation.adapter.ValidationContext;
+import io.avaje.validation.core.BasicTest;
+
+class EmailTest extends BasicTest {
+
+  static final ValidationContext ctx = (ValidationContext) validator;
+
+  @interface Email {}
+
+  ValidationAdapter<Object> notBlankAdapter = ctx.adapter(Email.class, Map.of("message", "email"));
+
+  @Test
+  void testNull() {
+    assertThat(notBlankAdapter.validate(null, request)).isTrue();
+  }
+
+  @Test
+  void testValid() {
+    assertThat(notBlankAdapter.validate("someEmail@gmail.com", request)).isTrue();
+  }
+
+  @Test
+  void testBlank() {
+    assertThat(notBlankAdapter.validate("", request)).isTrue();
+    assertThat(notBlankAdapter.validate("                    ", request)).isFalse();
+  }
+
+  @Test
+  void testInvalid() {
+    assertThat(notBlankAdapter.validate("notAnEmail", request)).isFalse();
+  }
+}

--- a/validator/src/test/java/io/avaje/validation/core/adapters/EmailTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/EmailTest.java
@@ -16,26 +16,26 @@ class EmailTest extends BasicTest {
 
   @interface Email {}
 
-  ValidationAdapter<Object> notBlankAdapter = ctx.adapter(Email.class, Map.of("message", "email"));
+  ValidationAdapter<Object> emailAdapter = ctx.adapter(Email.class, Map.of("message", "email"));
 
   @Test
   void testNull() {
-    assertThat(notBlankAdapter.validate(null, request)).isTrue();
+    assertThat(emailAdapter.validate(null, request)).isTrue();
   }
 
   @Test
   void testValid() {
-    assertThat(notBlankAdapter.validate("someEmail@gmail.com", request)).isTrue();
+    assertThat(emailAdapter.validate("someEmail@gmail.com", request)).isTrue();
   }
 
   @Test
   void testBlank() {
-    assertThat(notBlankAdapter.validate("", request)).isTrue();
-    assertThat(notBlankAdapter.validate("                    ", request)).isFalse();
+    assertThat(emailAdapter.validate("", request)).isTrue();
+    assertThat(emailAdapter.validate("                    ", request)).isFalse();
   }
 
   @Test
   void testInvalid() {
-    assertThat(notBlankAdapter.validate("notAnEmail", request)).isFalse();
+    assertThat(emailAdapter.validate("notAnEmail", request)).isFalse();
   }
 }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
@@ -43,7 +43,7 @@ class FuturePastAdapterTest extends BasicTest {
   void testPast() {
 
     Object value;
-    final var inst = Instant.now().minusMillis(1);
+    final var inst = Instant.now().minusMillis(50000);
 
     // Instant
     assertPast(inst);
@@ -137,14 +137,42 @@ class FuturePastAdapterTest extends BasicTest {
   void testPresent() {
 
     Object value;
+    final var inst = Instant.now();
 
-    // Instant/Date/DateTime classes are too precise for present test
+    // Instant
+    assertPresent(inst);
+
+    // date
+    value = Date.from(inst);
+
+    assertPresent(value);
 
     // LocalDate
     value = LocalDate.now();
 
     assertPresent(value);
 
+    // LocalDateTime
+    value = LocalDateTime.now();
+
+    assertPresent(value);
+    // LocalTime
+    value = LocalTime.now();
+
+    assertPresent(value);
+
+    // ZonedDateTime
+    value = ZonedDateTime.now();
+    assertPresent(value);
+
+    // OffsetDateTime
+    value = OffsetDateTime.now();
+
+    assertPresent(value);
+    // OffsetTime
+    value = OffsetTime.now();
+
+    assertPresent(value);
     // Year
     value = Year.now();
 
@@ -171,7 +199,5 @@ class FuturePastAdapterTest extends BasicTest {
   private void assertPresent(Object value) {
     assertThat(pastOrPresentAdapter.validate(value, request)).isTrue();
     assertThat(futureOrPresentAdapter.validate(value, request)).isTrue();
-    assertThat(pastAdapter.validate(value, request)).isFalse();
-    assertThat(futureAdapter.validate(value, request)).isFalse();
-  }
+   }
 }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
@@ -1,0 +1,204 @@
+package io.avaje.validation.core.adapters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Date;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.adapter.ValidationAdapter;
+import io.avaje.validation.core.BasicTest;
+
+class FuturePastAdapterTest extends BasicTest {
+
+  @interface Past {}
+
+  @interface Future {}
+
+  @interface PastOrPresent {}
+
+  @interface FutureOrPresent {}
+
+  ValidationAdapter<Object> pastAdapter = ctx.adapter(Past.class, Map.of("message", "wibbly"));
+  ValidationAdapter<Object> pastOrPresentAdapter =
+      ctx.adapter(PastOrPresent.class, Map.of("message", "wobbly"));
+  ValidationAdapter<Object> futureAdapter = ctx.adapter(Future.class, Map.of("message", "timey"));
+  ValidationAdapter<Object> futureOrPresentAdapter =
+      ctx.adapter(FutureOrPresent.class, Map.of("message", "wimey"));
+
+  @Test
+  void testNull() {
+    assertThat(pastAdapter.validate(null, request)).isTrue();
+    assertThat(pastOrPresentAdapter.validate(null, request)).isTrue();
+    assertThat(futureAdapter.validate(null, request)).isTrue();
+    assertThat(futureOrPresentAdapter.validate(null, request)).isTrue();
+  }
+
+  @Test
+  void testPast() {
+
+    Object value;
+    final var inst = Instant.now().minusMillis(1);
+
+    // Instant
+    assertPast(inst);
+
+    // date
+    value = Date.from(inst);
+
+    assertPast(value);
+    // LocalDate
+    value = LocalDate.now().minusDays(1);
+
+    assertPast(value);
+    // LocalDateTime
+    value = LocalDateTime.now().minusDays(1);
+
+    assertPast(value);
+    // LocalTime
+    value = LocalTime.now().minusHours(1);
+
+    assertPast(value);
+    // ZonedDateTime
+    value = ZonedDateTime.now().minusHours(1);
+
+    assertPast(value);
+    // OffsetDateTime
+    value = OffsetDateTime.now().minusHours(1);
+
+    assertPast(value);
+    // OffsetTime
+    value = OffsetTime.now().minusHours(1);
+
+    assertPast(value);
+    // Year
+    value = Year.now().minusYears(1);
+
+    assertPast(value);
+    // YearMonth
+    value = YearMonth.now().minusYears(1);
+    assertPast(value);
+  }
+
+  @Test
+  void testFuture() {
+
+    Object value;
+    final var inst = Instant.now().plusMillis(1234567890);
+
+    // Instant
+    assertFuture(inst);
+
+    // date
+    value = Date.from(inst);
+
+    assertFuture(value);
+
+    // LocalDate
+    value = LocalDate.now().plusDays(1);
+
+    assertFuture(value);
+
+    // LocalDateTime
+    value = LocalDateTime.now().plusDays(1);
+
+    assertFuture(value);
+    // LocalTime
+    value = LocalTime.now().plusMinutes(1);
+
+    assertFuture(value);
+    // ZonedDateTime
+    value = ZonedDateTime.now().plusHours(1);
+
+    assertFuture(value);
+    // OffsetDateTime
+    value = OffsetDateTime.now().plusHours(1);
+
+    assertFuture(value);
+    // OffsetTime
+    value = OffsetTime.now().plusMinutes(1);
+
+    assertFuture(value);
+    // Year
+    value = Year.now().plusYears(1);
+
+    assertFuture(value);
+    // YearMonth
+    value = YearMonth.now().plusYears(1);
+    assertFuture(value);
+  }
+
+  @Test
+  void testPresent() {
+
+    Object value;
+    final var inst = Instant.now();
+
+    // Instant
+    assertPresent(inst);
+
+    // date
+    value = Date.from(inst);
+
+    assertPresent(value);
+
+    // LocalDate
+    value = LocalDate.now();
+
+    assertPresent(value);
+
+    // LocalDateTime
+    value = LocalDateTime.now();
+
+    assertPresent(value);
+    // LocalTime
+    value = LocalTime.now();
+
+    assertPresent(value);
+    // ZonedDateTime
+    value = ZonedDateTime.now();
+
+    assertPresent(value);
+    // OffsetDateTime
+    value = OffsetDateTime.now();
+
+    assertPresent(value);
+    // OffsetTime
+    value = OffsetTime.now();
+
+    assertPresent(value);
+    // Year
+    value = Year.now();
+
+    assertPresent(value);
+    // YearMonth
+    value = YearMonth.now();
+    assertPresent(value);
+  }
+
+  private void assertPast(Object value) {
+    assertThat(pastAdapter.validate(value, request)).isTrue();
+    assertThat(pastOrPresentAdapter.validate(value, request)).isTrue();
+    assertThat(futureAdapter.validate(value, request)).isFalse();
+    assertThat(futureOrPresentAdapter.validate(value, request)).isFalse();
+  }
+
+  private void assertFuture(Object value) {
+    assertThat(pastAdapter.validate(value, request)).isFalse();
+    assertThat(pastOrPresentAdapter.validate(value, request)).isFalse();
+    assertThat(futureAdapter.validate(value, request)).isTrue();
+    assertThat(futureOrPresentAdapter.validate(value, request)).isTrue();
+  }
+
+  private void assertPresent(Object value) {
+    assertThat(pastOrPresentAdapter.validate(value, request)).isTrue();
+    assertThat(futureOrPresentAdapter.validate(value, request)).isTrue();
+    assertThat(pastAdapter.validate(value, request)).isFalse();
+    assertThat(futureAdapter.validate(value, request)).isFalse();
+  }
+}

--- a/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
@@ -61,20 +61,20 @@ class FuturePastAdapterTest extends BasicTest {
 
     assertPast(value);
     // LocalTime
-    value = LocalTime.now().minusHours(1);
+    value = LocalTime.now().minusMinutes(1);
 
     assertPast(value);
 
     // ZonedDateTime
-    value = ZonedDateTime.now().minusHours(1);
+    value = ZonedDateTime.now().minusMinutes(1);
 
     assertPast(value);
     // OffsetDateTime
-    value = OffsetDateTime.now().minusHours(1);
+    value = OffsetDateTime.now().minusMinutes(1);
 
     assertPast(value);
     // OffsetTime
-    value = OffsetTime.now().minusHours(1);
+    value = OffsetTime.now().minusMinutes(1);
 
     assertPast(value);
     // Year

--- a/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
@@ -61,7 +61,7 @@ class FuturePastAdapterTest extends BasicTest {
 
     assertPast(value);
     // LocalTime
-    value = LocalTime.now().minusHours(1);
+    value = LocalTime.now(). minusSeconds(134);
 
     assertPast(value);
     // ZonedDateTime

--- a/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
@@ -60,12 +60,10 @@ class FuturePastAdapterTest extends BasicTest {
     value = LocalDateTime.now().minusDays(1);
 
     assertPast(value);
-
     // LocalTime
     value = LocalTime.now().minusHours(1);
 
     assertPast(value);
-
     // ZonedDateTime
     value = ZonedDateTime.now().minusHours(1);
 

--- a/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
@@ -60,10 +60,12 @@ class FuturePastAdapterTest extends BasicTest {
     value = LocalDateTime.now().minusDays(1);
 
     assertPast(value);
+
     // LocalTime
     value = LocalTime.now().minusHours(1);
 
     assertPast(value);
+
     // ZonedDateTime
     value = ZonedDateTime.now().minusHours(1);
 

--- a/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
@@ -61,9 +61,10 @@ class FuturePastAdapterTest extends BasicTest {
 
     assertPast(value);
     // LocalTime
-    value = LocalTime.now(). minusSeconds(134);
+    value = LocalTime.now().minusHours(1);
 
     assertPast(value);
+
     // ZonedDateTime
     value = ZonedDateTime.now().minusHours(1);
 

--- a/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
@@ -137,40 +137,14 @@ class FuturePastAdapterTest extends BasicTest {
   void testPresent() {
 
     Object value;
-    final var inst = Instant.now();
 
-    // Instant
-    assertPresent(inst);
-
-    // date
-    value = Date.from(inst);
-
-    assertPresent(value);
+    // Instant/Date/DateTime classes are too precise for present test
 
     // LocalDate
     value = LocalDate.now();
 
     assertPresent(value);
 
-    // LocalDateTime
-    value = LocalDateTime.now();
-
-    assertPresent(value);
-    // LocalTime
-    value = LocalTime.now();
-
-    assertPresent(value);
-
-    // ZDT is too precise for a present test
-
-    // OffsetDateTime
-    value = OffsetDateTime.now();
-
-    assertPresent(value);
-    // OffsetTime
-    value = OffsetTime.now();
-
-    assertPresent(value);
     // Year
     value = Year.now();
 

--- a/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
@@ -139,8 +139,7 @@ class FuturePastAdapterTest extends BasicTest {
     Object value;
     final var inst = Instant.now();
 
-    // Instant
-    assertPresent(inst);
+    // Instant is too precise for a present test
 
     // date
     value = Date.from(inst);

--- a/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
@@ -139,7 +139,8 @@ class FuturePastAdapterTest extends BasicTest {
     Object value;
     final var inst = Instant.now();
 
-    // Instant is too precise for a present test
+    // Instant
+    assertPresent(inst);
 
     // date
     value = Date.from(inst);

--- a/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
@@ -160,10 +160,9 @@ class FuturePastAdapterTest extends BasicTest {
     value = LocalTime.now();
 
     assertPresent(value);
-    // ZonedDateTime
-    value = ZonedDateTime.now();
 
-    assertPresent(value);
+    // ZDT is too precise for a present test
+
     // OffsetDateTime
     value = OffsetDateTime.now();
 

--- a/validator/src/test/java/io/avaje/validation/core/adapters/MinMaxTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/MinMaxTest.java
@@ -18,10 +18,10 @@ class MinMaxTest extends BasicTest {
   @interface Max {}
 
   ValidationAdapter<Object> minAdapter =
-      ctx.adapter(Min.class, Map.of("message", "mini", "value", -69));
+      ctx.adapter(Min.class, Map.of("message", "mini", "value", -69L));
 
   ValidationAdapter<Object> maxAdapter =
-      ctx.adapter(Max.class, Map.of("message", "maxwell", "value", 69));
+      ctx.adapter(Max.class, Map.of("message", "maxwell", "value", 69L));
 
   @Test
   void testNull() {

--- a/validator/src/test/java/io/avaje/validation/core/adapters/MinMaxTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/MinMaxTest.java
@@ -1,0 +1,80 @@
+package io.avaje.validation.core.adapters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.adapter.ValidationAdapter;
+import io.avaje.validation.core.BasicTest;
+
+class MinMaxTest extends BasicTest {
+
+  @interface Min {}
+
+  @interface Max {}
+
+  ValidationAdapter<Object> minAdapter =
+      ctx.adapter(Min.class, Map.of("message", "mini", "value", -69));
+
+  ValidationAdapter<Object> maxAdapter =
+      ctx.adapter(Max.class, Map.of("message", "maxwell", "value", 69));
+
+  @Test
+  void testNull() {
+    assertThat(minAdapter.validate(null, request)).isTrue();
+    assertThat(maxAdapter.validate(null, request)).isTrue();
+  }
+
+  @Test
+  void testMax() {
+
+    assertThat(maxAdapter.validate(0, request)).isTrue();
+    assertThat(maxAdapter.validate(0f, request)).isTrue();
+    assertThat(maxAdapter.validate(0D, request)).isTrue();
+    assertThat(maxAdapter.validate(0L, request)).isTrue();
+    assertThat(maxAdapter.validate((short) 0, request)).isTrue();
+    assertThat(maxAdapter.validate((byte) 0, request)).isTrue();
+    assertThat(maxAdapter.validate(BigInteger.valueOf(0), request)).isTrue();
+    assertThat(maxAdapter.validate(BigDecimal.valueOf(0), request)).isTrue();
+  }
+
+  @Test
+  void testMin() {
+    assertThat(minAdapter.validate(-0, request)).isTrue();
+    assertThat(minAdapter.validate(-0f, request)).isTrue();
+    assertThat(minAdapter.validate(-0D, request)).isTrue();
+    assertThat(minAdapter.validate(-0L, request)).isTrue();
+    assertThat(minAdapter.validate((short) -0, request)).isTrue();
+    assertThat(minAdapter.validate((byte) -0, request)).isTrue();
+    assertThat(minAdapter.validate(BigInteger.valueOf(-0), request)).isTrue();
+    assertThat(minAdapter.validate(BigDecimal.valueOf(-0), request)).isTrue();
+  }
+
+  @Test
+  void testMaxInValid() {
+    assertThat(maxAdapter.validate(01234, request)).isFalse();
+    assertThat(maxAdapter.validate(01234f, request)).isFalse();
+    assertThat(maxAdapter.validate(01234D, request)).isFalse();
+    assertThat(maxAdapter.validate(01234L, request)).isFalse();
+    assertThat(maxAdapter.validate((short) 01234, request)).isFalse();
+    assertThat(maxAdapter.validate((byte) 01234567, request)).isFalse();
+    assertThat(maxAdapter.validate(BigInteger.valueOf(01234), request)).isFalse();
+    assertThat(maxAdapter.validate(BigDecimal.valueOf(01234), request)).isFalse();
+  }
+
+  @Test
+  void testMinInValid() {
+    assertThat(minAdapter.validate(-01234, request)).isFalse();
+    assertThat(minAdapter.validate(-01234f, request)).isFalse();
+    assertThat(minAdapter.validate(-01234D, request)).isFalse();
+    assertThat(minAdapter.validate(-01234L, request)).isFalse();
+    assertThat(minAdapter.validate((short) -01234, request)).isFalse();
+    assertThat(minAdapter.validate((byte) -01234567, request)).isFalse();
+    assertThat(minAdapter.validate(BigInteger.valueOf(-01234), request)).isFalse();
+    assertThat(minAdapter.validate(BigDecimal.valueOf(-01234), request)).isFalse();
+  }
+}

--- a/validator/src/test/java/io/avaje/validation/core/adapters/NegativeTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/NegativeTest.java
@@ -1,0 +1,92 @@
+package io.avaje.validation.core.adapters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.adapter.ValidationAdapter;
+import io.avaje.validation.core.BasicTest;
+
+class NegativeTest extends BasicTest {
+
+  @interface Negative {}
+
+  @interface NegativeOrZero {}
+
+  ValidationAdapter<Object> negativeAdapter =
+      ctx.adapter(Negative.class, Map.of("message", "elim-"));
+  ValidationAdapter<Object> negativeOrZeroAdapter =
+      ctx.adapter(NegativeOrZero.class, Map.of("message", "-anate the negative"));
+
+  @Test
+  void testNull() {
+    assertThat(negativeAdapter.validate(null, request)).isTrue();
+  }
+
+  @Test
+  void testPositive() {
+    assertThat(negativeAdapter.validate(1, request)).isFalse();
+    assertThat(negativeAdapter.validate(1f, request)).isFalse();
+    assertThat(negativeAdapter.validate(1D, request)).isFalse();
+    assertThat(negativeAdapter.validate(1L, request)).isFalse();
+    assertThat(negativeAdapter.validate((short) 1, request)).isFalse();
+    assertThat(negativeAdapter.validate((byte) 1, request)).isFalse();
+    assertThat(negativeAdapter.validate(BigInteger.ONE, request)).isFalse();
+    assertThat(negativeAdapter.validate(BigDecimal.ONE, request)).isFalse();
+
+    assertThat(negativeOrZeroAdapter.validate(1, request)).isFalse();
+    assertThat(negativeOrZeroAdapter.validate(1f, request)).isFalse();
+    assertThat(negativeOrZeroAdapter.validate(1D, request)).isFalse();
+    assertThat(negativeOrZeroAdapter.validate(1L, request)).isFalse();
+    assertThat(negativeOrZeroAdapter.validate((short) 1, request)).isFalse();
+    assertThat(negativeOrZeroAdapter.validate((byte) 1, request)).isFalse();
+    assertThat(negativeOrZeroAdapter.validate(BigInteger.ONE, request)).isFalse();
+    assertThat(negativeOrZeroAdapter.validate(BigDecimal.ONE, request)).isFalse();
+  }
+
+  @Test
+  void testNegative() {
+    assertThat(negativeAdapter.validate(-1, request)).isTrue();
+    assertThat(negativeAdapter.validate(-1f, request)).isTrue();
+    assertThat(negativeAdapter.validate(-1D, request)).isTrue();
+    assertThat(negativeAdapter.validate(-1L, request)).isTrue();
+    assertThat(negativeAdapter.validate((short) -1, request)).isTrue();
+    assertThat(negativeAdapter.validate((byte) -1, request)).isTrue();
+    assertThat(negativeAdapter.validate(BigInteger.valueOf(-1), request)).isTrue();
+    assertThat(negativeAdapter.validate(BigDecimal.valueOf(-1), request)).isTrue();
+
+    assertThat(negativeOrZeroAdapter.validate(-1, request)).isTrue();
+    assertThat(negativeOrZeroAdapter.validate(-1f, request)).isTrue();
+    assertThat(negativeOrZeroAdapter.validate(-1D, request)).isTrue();
+    assertThat(negativeOrZeroAdapter.validate(-1L, request)).isTrue();
+    assertThat(negativeOrZeroAdapter.validate((short) -1, request)).isTrue();
+    assertThat(negativeOrZeroAdapter.validate((byte) -1, request)).isTrue();
+    assertThat(negativeOrZeroAdapter.validate(BigInteger.valueOf(-1), request)).isTrue();
+    assertThat(negativeOrZeroAdapter.validate(BigDecimal.valueOf(-1), request)).isTrue();
+  }
+
+  @Test
+  void testZero() {
+    assertThat(negativeAdapter.validate(0, request)).isFalse();
+    assertThat(negativeAdapter.validate(0f, request)).isFalse();
+    assertThat(negativeAdapter.validate(0D, request)).isFalse();
+    assertThat(negativeAdapter.validate(0L, request)).isFalse();
+    assertThat(negativeAdapter.validate((short) 0, request)).isFalse();
+    assertThat(negativeAdapter.validate((byte) 0, request)).isFalse();
+    assertThat(negativeAdapter.validate(BigInteger.ZERO, request)).isFalse();
+    assertThat(negativeAdapter.validate(BigDecimal.ZERO, request)).isFalse();
+
+    assertThat(negativeOrZeroAdapter.validate(0, request)).isTrue();
+    assertThat(negativeOrZeroAdapter.validate(0f, request)).isTrue();
+    assertThat(negativeOrZeroAdapter.validate(0D, request)).isTrue();
+    assertThat(negativeOrZeroAdapter.validate(0L, request)).isTrue();
+    assertThat(negativeOrZeroAdapter.validate((short) 0, request)).isTrue();
+    assertThat(negativeOrZeroAdapter.validate((byte) 0, request)).isTrue();
+    assertThat(negativeOrZeroAdapter.validate(BigInteger.ZERO, request)).isTrue();
+    assertThat(negativeOrZeroAdapter.validate(BigDecimal.ZERO, request)).isTrue();
+  }
+}

--- a/validator/src/test/java/io/avaje/validation/core/adapters/NegativeTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/NegativeTest.java
@@ -25,10 +25,25 @@ class NegativeTest extends BasicTest {
   @Test
   void testNull() {
     assertThat(negativeAdapter.validate(null, request)).isTrue();
+    assertThat(negativeOrZeroAdapter.validate(null, request)).isTrue();
+  }
+
+  @Test
+  void testInfinity() {
+    assertThat(negativeAdapter.validate(Float.POSITIVE_INFINITY, request)).isFalse();
+    assertThat(negativeAdapter.validate(Double.POSITIVE_INFINITY, request)).isFalse();
+    assertThat(negativeOrZeroAdapter.validate(Float.POSITIVE_INFINITY, request)).isFalse();
+    assertThat(negativeOrZeroAdapter.validate(Double.POSITIVE_INFINITY, request)).isFalse();
+
+    assertThat(negativeAdapter.validate(Float.NEGATIVE_INFINITY, request)).isTrue();
+    assertThat(negativeAdapter.validate(Double.NEGATIVE_INFINITY, request)).isTrue();
+    assertThat(negativeOrZeroAdapter.validate(Float.NEGATIVE_INFINITY, request)).isTrue();
+    assertThat(negativeOrZeroAdapter.validate(Double.NEGATIVE_INFINITY, request)).isTrue();
   }
 
   @Test
   void testPositive() {
+    assertThat(negativeAdapter.validate("1", request)).isFalse();
     assertThat(negativeAdapter.validate(1, request)).isFalse();
     assertThat(negativeAdapter.validate(1f, request)).isFalse();
     assertThat(negativeAdapter.validate(1D, request)).isFalse();
@@ -38,6 +53,7 @@ class NegativeTest extends BasicTest {
     assertThat(negativeAdapter.validate(BigInteger.ONE, request)).isFalse();
     assertThat(negativeAdapter.validate(BigDecimal.ONE, request)).isFalse();
 
+    assertThat(negativeOrZeroAdapter.validate("1", request)).isFalse();
     assertThat(negativeOrZeroAdapter.validate(1, request)).isFalse();
     assertThat(negativeOrZeroAdapter.validate(1f, request)).isFalse();
     assertThat(negativeOrZeroAdapter.validate(1D, request)).isFalse();
@@ -50,6 +66,7 @@ class NegativeTest extends BasicTest {
 
   @Test
   void testNegative() {
+    assertThat(negativeAdapter.validate("-1", request)).isTrue();
     assertThat(negativeAdapter.validate(-1, request)).isTrue();
     assertThat(negativeAdapter.validate(-1f, request)).isTrue();
     assertThat(negativeAdapter.validate(-1D, request)).isTrue();
@@ -59,6 +76,7 @@ class NegativeTest extends BasicTest {
     assertThat(negativeAdapter.validate(BigInteger.valueOf(-1), request)).isTrue();
     assertThat(negativeAdapter.validate(BigDecimal.valueOf(-1), request)).isTrue();
 
+    assertThat(negativeOrZeroAdapter.validate("-1", request)).isTrue();
     assertThat(negativeOrZeroAdapter.validate(-1, request)).isTrue();
     assertThat(negativeOrZeroAdapter.validate(-1f, request)).isTrue();
     assertThat(negativeOrZeroAdapter.validate(-1D, request)).isTrue();
@@ -71,6 +89,7 @@ class NegativeTest extends BasicTest {
 
   @Test
   void testZero() {
+    assertThat(negativeAdapter.validate("0", request)).isFalse();
     assertThat(negativeAdapter.validate(0, request)).isFalse();
     assertThat(negativeAdapter.validate(0f, request)).isFalse();
     assertThat(negativeAdapter.validate(0D, request)).isFalse();
@@ -80,6 +99,7 @@ class NegativeTest extends BasicTest {
     assertThat(negativeAdapter.validate(BigInteger.ZERO, request)).isFalse();
     assertThat(negativeAdapter.validate(BigDecimal.ZERO, request)).isFalse();
 
+    assertThat(negativeOrZeroAdapter.validate("0", request)).isTrue();
     assertThat(negativeOrZeroAdapter.validate(0, request)).isTrue();
     assertThat(negativeOrZeroAdapter.validate(0f, request)).isTrue();
     assertThat(negativeOrZeroAdapter.validate(0D, request)).isTrue();

--- a/validator/src/test/java/io/avaje/validation/core/adapters/NotBlankTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/NotBlankTest.java
@@ -1,0 +1,37 @@
+package io.avaje.validation.core.adapters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.adapter.ValidationAdapter;
+import io.avaje.validation.adapter.ValidationContext;
+import io.avaje.validation.core.BasicTest;
+
+class NotBlankTest extends BasicTest {
+
+  static final ValidationContext ctx = (ValidationContext) validator;
+
+  @interface NotBlank {}
+
+  ValidationAdapter<Object> notBlankAdapter =
+      ctx.adapter(NotBlank.class, Map.of("message", "blank?"));
+
+  @Test
+  void testNull() {
+    assertThat(notBlankAdapter.validate(null, request)).isFalse();
+  }
+
+  @Test
+  void testNotBlank() {
+    assertThat(notBlankAdapter.validate("something", request)).isTrue();
+  }
+
+  @Test
+  void testBlank() {
+    assertThat(notBlankAdapter.validate("", request)).isFalse();
+    assertThat(notBlankAdapter.validate("                    ", request)).isFalse();
+  }
+}

--- a/validator/src/test/java/io/avaje/validation/core/adapters/NotEmptyTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/NotEmptyTest.java
@@ -45,4 +45,17 @@ class NotEmptyTest extends BasicTest {
     assertThat(notEmptyAdapter.validate(new int[] {}, request)).isFalse();
     assertThat(notEmptyAdapter.validate("", request)).isFalse();
   }
+
+  @Test
+  void testArrays() {
+    assertThat(notEmptyAdapter.validate(new int[] {1}, request)).isTrue();
+    assertThat(notEmptyAdapter.validate(new byte[] {1}, request)).isTrue();
+    assertThat(notEmptyAdapter.validate(new boolean[] {true}, request)).isTrue();
+    assertThat(notEmptyAdapter.validate(new char[] {'d'}, request)).isTrue();
+    assertThat(notEmptyAdapter.validate(new float[] {1}, request)).isTrue();
+    assertThat(notEmptyAdapter.validate(new short[] {1}, request)).isTrue();
+    assertThat(notEmptyAdapter.validate(new double[] {1}, request)).isTrue();
+    assertThat(notEmptyAdapter.validate(new long[] {1}, request)).isTrue();
+    assertThat(notEmptyAdapter.validate(new String[] {""}, request)).isTrue();
+  }
 }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/NotEmptyTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/NotEmptyTest.java
@@ -1,0 +1,48 @@
+package io.avaje.validation.core.adapters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.adapter.ValidationAdapter;
+import io.avaje.validation.adapter.ValidationContext;
+import io.avaje.validation.core.BasicTest;
+
+class NotEmptyTest extends BasicTest {
+
+  static final ValidationContext ctx = (ValidationContext) validator;
+
+  @interface NotEmpty {}
+
+  ValidationAdapter<Object> notEmptyAdapter =
+      ctx.adapter(NotEmpty.class, Map.of("message", "this can empty. *chucks it*"));
+
+  @Test
+  void testNull() {
+    assertThat(notEmptyAdapter.validate(null, request)).isFalse();
+  }
+
+  @Test
+  void testNotEmpty() {
+    assertThat(notEmptyAdapter.validate("something", request)).isTrue();
+    // length of characters, not whitespace
+    assertThat(notEmptyAdapter.validate("                    ", request)).isTrue();
+    assertThat(notEmptyAdapter.validate(Map.of(1, 2), request)).isTrue();
+    assertThat(notEmptyAdapter.validate(List.of(1), request)).isTrue();
+    assertThat(notEmptyAdapter.validate(Set.of(1), request)).isTrue();
+    assertThat(notEmptyAdapter.validate(new int[] {1}, request)).isTrue();
+  }
+
+  @Test
+  void testEmpty() {
+    assertThat(notEmptyAdapter.validate(Map.of(), request)).isFalse();
+    assertThat(notEmptyAdapter.validate(List.of(), request)).isFalse();
+    assertThat(notEmptyAdapter.validate(Set.of(), request)).isFalse();
+    assertThat(notEmptyAdapter.validate(new int[] {}, request)).isFalse();
+    assertThat(notEmptyAdapter.validate("", request)).isFalse();
+  }
+}

--- a/validator/src/test/java/io/avaje/validation/core/adapters/NullableAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/NullableAdapterTest.java
@@ -1,0 +1,39 @@
+package io.avaje.validation.core.adapters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.adapter.ValidationAdapter;
+import io.avaje.validation.core.BasicTest;
+
+class NullableAdapterTest extends BasicTest {
+
+  @interface Null {}
+
+  @interface NotNull {}
+
+  @interface NonNull {}
+
+  ValidationAdapter<Object> nulladapter = ctx.adapter(Null.class, Map.of("message", "be null"));
+  ValidationAdapter<Object> notNulladapter =
+      ctx.adapter(NotNull.class, Map.of("message", "Not be null"));
+  ValidationAdapter<Object> nonNulladapter =
+      ctx.adapter(NonNull.class, Map.of("message", "Non be null"));
+
+  @Test
+  void testNull() {
+    assertThat(nulladapter.validate(null, request)).isTrue();
+    assertThat(notNulladapter.validate(null, request)).isFalse();
+    assertThat(nonNulladapter.validate(null, request)).isFalse();
+  }
+
+  @Test
+  void testNotNull() {
+    assertThat(nulladapter.validate(0, request)).isFalse();
+    assertThat(notNulladapter.validate(0, request)).isTrue();
+    assertThat(nonNulladapter.validate(0, request)).isTrue();
+  }
+}

--- a/validator/src/test/java/io/avaje/validation/core/adapters/PatternTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/PatternTest.java
@@ -1,0 +1,52 @@
+package io.avaje.validation.core.adapters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.adapter.RegexFlag;
+import io.avaje.validation.adapter.ValidationAdapter;
+import io.avaje.validation.adapter.ValidationContext;
+import io.avaje.validation.core.BasicTest;
+
+class PatternTest extends BasicTest {
+
+  static final ValidationContext ctx = (ValidationContext) validator;
+
+  @interface Pattern {}
+
+  ValidationAdapter<Object> patternAdapter =
+      ctx.adapter(
+          Pattern.class,
+          Map.of(
+              "message",
+              "peppermint patty",
+              "regexp",
+              "¯\\\\_\\(ツ\\)_/¯",
+              "flags",
+              List.of(RegexFlag.CANON_EQ)));
+
+  @Test
+  void testNull() {
+    assertThat(patternAdapter.validate(null, request)).isTrue();
+  }
+
+  @Test
+  void testValid() {
+    assertThat(patternAdapter.validate("¯\\_(ツ)_/¯", request)).isTrue();
+  }
+
+  @Test
+  void testBlank() {
+    assertThat(patternAdapter.validate("", request)).isFalse();
+    assertThat(patternAdapter.validate("                    ", request)).isFalse();
+  }
+
+  @Test
+  void testInvalid() {
+    assertThat(patternAdapter.validate("notAnEmail", request)).isFalse();
+  }
+}

--- a/validator/src/test/java/io/avaje/validation/core/adapters/PositiveTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/PositiveTest.java
@@ -1,0 +1,92 @@
+package io.avaje.validation.core.adapters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.adapter.ValidationAdapter;
+import io.avaje.validation.core.BasicTest;
+
+class PositiveTest extends BasicTest {
+
+  @interface Positive {}
+
+  @interface PositiveOrZero {}
+
+  ValidationAdapter<Object> positiveAdapter =
+      ctx.adapter(Positive.class, Map.of("message", "you gotta accent-"));
+  ValidationAdapter<Object> positiveOrZeroAdapter =
+      ctx.adapter(PositiveOrZero.class, Map.of("message", "-tuate the positive"));
+
+  @Test
+  void testNull() {
+    assertThat(positiveAdapter.validate(null, request)).isTrue();
+  }
+
+  @Test
+  void testPositive() {
+    assertThat(positiveAdapter.validate(1, request)).isTrue();
+    assertThat(positiveAdapter.validate(1f, request)).isTrue();
+    assertThat(positiveAdapter.validate(1D, request)).isTrue();
+    assertThat(positiveAdapter.validate(1L, request)).isTrue();
+    assertThat(positiveAdapter.validate((short) 1, request)).isTrue();
+    assertThat(positiveAdapter.validate((byte) 1, request)).isTrue();
+    assertThat(positiveAdapter.validate(BigInteger.ONE, request)).isTrue();
+    assertThat(positiveAdapter.validate(BigDecimal.ONE, request)).isTrue();
+
+    assertThat(positiveOrZeroAdapter.validate(1, request)).isTrue();
+    assertThat(positiveOrZeroAdapter.validate(1f, request)).isTrue();
+    assertThat(positiveOrZeroAdapter.validate(1D, request)).isTrue();
+    assertThat(positiveOrZeroAdapter.validate(1L, request)).isTrue();
+    assertThat(positiveOrZeroAdapter.validate((short) 1, request)).isTrue();
+    assertThat(positiveOrZeroAdapter.validate((byte) 1, request)).isTrue();
+    assertThat(positiveOrZeroAdapter.validate(BigInteger.ONE, request)).isTrue();
+    assertThat(positiveOrZeroAdapter.validate(BigDecimal.ONE, request)).isTrue();
+  }
+
+  @Test
+  void testNegative() {
+    assertThat(positiveAdapter.validate(-1, request)).isFalse();
+    assertThat(positiveAdapter.validate(-1f, request)).isFalse();
+    assertThat(positiveAdapter.validate(-1D, request)).isFalse();
+    assertThat(positiveAdapter.validate(-1L, request)).isFalse();
+    assertThat(positiveAdapter.validate((short) -1, request)).isFalse();
+    assertThat(positiveAdapter.validate((byte) -1, request)).isFalse();
+    assertThat(positiveAdapter.validate(BigInteger.valueOf(-1), request)).isFalse();
+    assertThat(positiveAdapter.validate(BigDecimal.valueOf(-1), request)).isFalse();
+
+    assertThat(positiveOrZeroAdapter.validate(-1, request)).isFalse();
+    assertThat(positiveOrZeroAdapter.validate(-1f, request)).isFalse();
+    assertThat(positiveOrZeroAdapter.validate(-1D, request)).isFalse();
+    assertThat(positiveOrZeroAdapter.validate(-1L, request)).isFalse();
+    assertThat(positiveOrZeroAdapter.validate((short) -1, request)).isFalse();
+    assertThat(positiveOrZeroAdapter.validate((byte) -1, request)).isFalse();
+    assertThat(positiveOrZeroAdapter.validate(BigInteger.valueOf(-1), request)).isFalse();
+    assertThat(positiveOrZeroAdapter.validate(BigDecimal.valueOf(-1), request)).isFalse();
+  }
+
+  @Test
+  void testZero() {
+    assertThat(positiveAdapter.validate(0, request)).isFalse();
+    assertThat(positiveAdapter.validate(0f, request)).isFalse();
+    assertThat(positiveAdapter.validate(0D, request)).isFalse();
+    assertThat(positiveAdapter.validate(0L, request)).isFalse();
+    assertThat(positiveAdapter.validate((short) 0, request)).isFalse();
+    assertThat(positiveAdapter.validate((byte) 0, request)).isFalse();
+    assertThat(positiveAdapter.validate(BigInteger.ZERO, request)).isFalse();
+    assertThat(positiveAdapter.validate(BigDecimal.ZERO, request)).isFalse();
+
+    assertThat(positiveOrZeroAdapter.validate(0, request)).isTrue();
+    assertThat(positiveOrZeroAdapter.validate(0f, request)).isTrue();
+    assertThat(positiveOrZeroAdapter.validate(0D, request)).isTrue();
+    assertThat(positiveOrZeroAdapter.validate(0L, request)).isTrue();
+    assertThat(positiveOrZeroAdapter.validate((short) 0, request)).isTrue();
+    assertThat(positiveOrZeroAdapter.validate((byte) 0, request)).isTrue();
+    assertThat(positiveOrZeroAdapter.validate(BigInteger.ZERO, request)).isTrue();
+    assertThat(positiveOrZeroAdapter.validate(BigDecimal.ZERO, request)).isTrue();
+  }
+}

--- a/validator/src/test/java/io/avaje/validation/core/adapters/PositiveTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/PositiveTest.java
@@ -25,10 +25,25 @@ class PositiveTest extends BasicTest {
   @Test
   void testNull() {
     assertThat(positiveAdapter.validate(null, request)).isTrue();
+    assertThat(positiveOrZeroAdapter.validate(null, request)).isTrue();
+  }
+
+  @Test
+  void testInfinity() {
+    assertThat(positiveAdapter.validate(Float.POSITIVE_INFINITY, request)).isTrue();
+    assertThat(positiveAdapter.validate(Double.POSITIVE_INFINITY, request)).isTrue();
+    assertThat(positiveOrZeroAdapter.validate(Float.POSITIVE_INFINITY, request)).isTrue();
+    assertThat(positiveOrZeroAdapter.validate(Double.POSITIVE_INFINITY, request)).isTrue();
+
+    assertThat(positiveAdapter.validate(Float.NEGATIVE_INFINITY, request)).isFalse();
+    assertThat(positiveAdapter.validate(Double.NEGATIVE_INFINITY, request)).isFalse();
+    assertThat(positiveOrZeroAdapter.validate(Float.NEGATIVE_INFINITY, request)).isFalse();
+    assertThat(positiveOrZeroAdapter.validate(Double.NEGATIVE_INFINITY, request)).isFalse();
   }
 
   @Test
   void testPositive() {
+    assertThat(positiveAdapter.validate("1", request)).isTrue();
     assertThat(positiveAdapter.validate(1, request)).isTrue();
     assertThat(positiveAdapter.validate(1f, request)).isTrue();
     assertThat(positiveAdapter.validate(1D, request)).isTrue();
@@ -38,6 +53,7 @@ class PositiveTest extends BasicTest {
     assertThat(positiveAdapter.validate(BigInteger.ONE, request)).isTrue();
     assertThat(positiveAdapter.validate(BigDecimal.ONE, request)).isTrue();
 
+    assertThat(positiveOrZeroAdapter.validate("1", request)).isTrue();
     assertThat(positiveOrZeroAdapter.validate(1, request)).isTrue();
     assertThat(positiveOrZeroAdapter.validate(1f, request)).isTrue();
     assertThat(positiveOrZeroAdapter.validate(1D, request)).isTrue();
@@ -50,6 +66,8 @@ class PositiveTest extends BasicTest {
 
   @Test
   void testNegative() {
+
+    assertThat(positiveAdapter.validate("-1", request)).isFalse();
     assertThat(positiveAdapter.validate(-1, request)).isFalse();
     assertThat(positiveAdapter.validate(-1f, request)).isFalse();
     assertThat(positiveAdapter.validate(-1D, request)).isFalse();
@@ -59,6 +77,7 @@ class PositiveTest extends BasicTest {
     assertThat(positiveAdapter.validate(BigInteger.valueOf(-1), request)).isFalse();
     assertThat(positiveAdapter.validate(BigDecimal.valueOf(-1), request)).isFalse();
 
+    assertThat(positiveOrZeroAdapter.validate("-1", request)).isFalse();
     assertThat(positiveOrZeroAdapter.validate(-1, request)).isFalse();
     assertThat(positiveOrZeroAdapter.validate(-1f, request)).isFalse();
     assertThat(positiveOrZeroAdapter.validate(-1D, request)).isFalse();
@@ -71,6 +90,7 @@ class PositiveTest extends BasicTest {
 
   @Test
   void testZero() {
+    assertThat(positiveAdapter.validate("0", request)).isFalse();
     assertThat(positiveAdapter.validate(0, request)).isFalse();
     assertThat(positiveAdapter.validate(0f, request)).isFalse();
     assertThat(positiveAdapter.validate(0D, request)).isFalse();
@@ -80,6 +100,7 @@ class PositiveTest extends BasicTest {
     assertThat(positiveAdapter.validate(BigInteger.ZERO, request)).isFalse();
     assertThat(positiveAdapter.validate(BigDecimal.ZERO, request)).isFalse();
 
+    assertThat(positiveOrZeroAdapter.validate("0", request)).isTrue();
     assertThat(positiveOrZeroAdapter.validate(0, request)).isTrue();
     assertThat(positiveOrZeroAdapter.validate(0f, request)).isTrue();
     assertThat(positiveOrZeroAdapter.validate(0D, request)).isTrue();

--- a/validator/src/test/java/io/avaje/validation/core/adapters/SizeTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/SizeTest.java
@@ -1,0 +1,67 @@
+package io.avaje.validation.core.adapters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.adapter.ValidationAdapter;
+import io.avaje.validation.adapter.ValidationContext;
+import io.avaje.validation.core.BasicTest;
+
+class SizeTest extends BasicTest {
+
+  static final ValidationContext ctx = (ValidationContext) validator;
+
+  @interface Size {}
+
+  ValidationAdapter<Object> sizeAdapter =
+      ctx.adapter(Size.class, Map.of("message", "blank?", "min", 2, "max", 3));
+
+  @Test
+  void testNull() {
+    // null elements are considered valid.
+    assertThat(sizeAdapter.validate(null, request)).isTrue();
+  }
+
+  @Test
+  void testWithinSize() {
+    assertThat(sizeAdapter.validate(Map.of(1, 2,3,4), request)).isTrue();
+    assertThat(sizeAdapter.validate(List.of(1, 2), request)).isTrue();
+    assertThat(sizeAdapter.validate(Set.of(1, 2), request)).isTrue();
+    assertThat(sizeAdapter.validate(new int[] {1, 2,}, request)).isTrue();
+    assertThat(sizeAdapter.validate("12", request)).isTrue();
+  }
+
+  @Test
+  void testSmallerSize() {
+    assertThat(sizeAdapter.validate("1", request)).isFalse();
+    // if greater than 0 continue validation
+    assertThat(sizeAdapter.validate(Map.of(1, 2), request)).isTrue();
+    assertThat(sizeAdapter.validate(List.of(1), request)).isTrue();
+    assertThat(sizeAdapter.validate(Set.of(1), request)).isTrue();
+    assertThat(sizeAdapter.validate(new int[] {1}, request)).isTrue();
+  }
+
+  @Test
+  void test0Size() {
+    assertThat(sizeAdapter.validate(Map.of(), request)).isFalse();
+    assertThat(sizeAdapter.validate(List.of(), request)).isFalse();
+    assertThat(sizeAdapter.validate(Set.of(), request)).isFalse();
+    assertThat(sizeAdapter.validate(new int[] {}, request)).isFalse();
+    assertThat(sizeAdapter.validate("", request)).isFalse();
+  }
+
+  @Test
+  void testBiggerSize() {
+    assertThat(sizeAdapter.validate("it's too big", request)).isFalse();
+    // if greater than 0 continue validation
+    assertThat(sizeAdapter.validate(Map.of(1, 2, 3, 4, 5, 6, 7, 8), request)).isTrue();
+    assertThat(sizeAdapter.validate(List.of(1, 2, 3, 4), request)).isTrue();
+    assertThat(sizeAdapter.validate(Set.of(1, 2, 3, 4), request)).isTrue();
+    assertThat(sizeAdapter.validate(new int[] {1, 2, 3, 4}, request)).isTrue();
+  }
+}


### PR DESCRIPTION
As the title says.


- Fixes null handling with boolean values
- fix Min/Max adapters casting issue (can't cast Object to long if it's an int)
- refactor FuturePastAdapter to be simple and use a referenceClock for tolerance (somewhat similar algo to how hibernate does it)
- no longer uses reflection to check array length