### PR TITLE
Convert Method Validator into a Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
     <java.version>17</java.version>
     <java.release>17</java.release>
-    <inject.version>9.3</inject.version>
+    <inject.version>9.4-SNAPSHOT</inject.version>
     <http.version>1.45</http.version>
   </properties>
 

--- a/validator-generator/src/main/java/io/avaje/validation/generator/AdapterHelper.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/AdapterHelper.java
@@ -33,25 +33,26 @@ public class AdapterHelper {
 
     if (!typeUse1.isEmpty()
         && (isAssignable2Interface(genericType.topType(), "java.lang.Iterable"))) {
-      writer.append("%s    .list()", indent);
+      writer.eol().append("%s    .list()", indent);
       final var t = genericType.firstParamType();
       writeTypeUse(writer, indent, t, typeUse1, genericType);
 
     } else if ((!typeUse1.isEmpty() || !typeUse2.isEmpty())
         && "java.util.Map".equals(genericType.topType())) {
 
-      writer.append("%s    .mapKeys()", indent);
+      writer.eol().append("%s    .mapKeys()", indent);
       writeTypeUse(writer, indent, genericType.firstParamType(), typeUse1, genericType);
 
-      writer.append("%s    .mapValues()", indent);
+      writer.eol().append("%s    .mapValues()", indent);
       writeTypeUse(writer, indent, genericType.secondParamType(), typeUse2, false, genericType);
 
     } else if (genericType.topType().contains("[]") && hasValid) {
 
-      writer.append("%s    .array()", indent);
+      writer.eol().append("%s    .array()", indent);
       writeTypeUse(writer, indent, genericType.firstParamType(), typeUse1, genericType);
     } else if (hasValid) {
       writer
+          .eol()
           .append(
               "%s    .andThen(ctx.adapter(%s.class))",
               indent, Util.shortName(genericType.topType()));
@@ -84,7 +85,7 @@ public class AdapterHelper {
       }
       final var k = a.getKey().shortName();
       final var v = a.getValue();
-      writer.append("%s    .andThenMulti(ctx.adapter(%s.class,%s))", indent, k, v);
+      writer.eol().append("%s    .andThenMulti(ctx.adapter(%s.class,%s))", indent, k, v);
     }
 
     if (!Util.isBasicType(paramType)
@@ -93,6 +94,7 @@ public class AdapterHelper {
             .anyMatch(Constants.VALID_ANNOTATIONS::contains)) {
 
       writer
+          .eol()
           .append(
               "%s    .andThenMulti(ctx.adapter(%s.class))",
               indent,

--- a/validator-generator/src/main/java/io/avaje/validation/generator/AdapterHelper.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/AdapterHelper.java
@@ -33,26 +33,25 @@ public class AdapterHelper {
 
     if (!typeUse1.isEmpty()
         && (isAssignable2Interface(genericType.topType(), "java.lang.Iterable"))) {
-      writer.eol().append("%s    .list()", indent);
+      writer.append("%s    .list()", indent);
       final var t = genericType.firstParamType();
       writeTypeUse(writer, indent, t, typeUse1, genericType);
 
     } else if ((!typeUse1.isEmpty() || !typeUse2.isEmpty())
         && "java.util.Map".equals(genericType.topType())) {
 
-      writer.eol().append("%s    .mapKeys()", indent);
+      writer.append("%s    .mapKeys()", indent);
       writeTypeUse(writer, indent, genericType.firstParamType(), typeUse1, genericType);
 
-      writer.eol().append("%s    .mapValues()", indent);
+      writer.append("%s    .mapValues()", indent);
       writeTypeUse(writer, indent, genericType.secondParamType(), typeUse2, false, genericType);
 
     } else if (genericType.topType().contains("[]") && hasValid) {
 
-      writer.eol().append("%s    .array()", indent);
+      writer.append("%s    .array()", indent);
       writeTypeUse(writer, indent, genericType.firstParamType(), typeUse1, genericType);
     } else if (hasValid) {
       writer
-          .eol()
           .append(
               "%s    .andThen(ctx.adapter(%s.class))",
               indent, Util.shortName(genericType.topType()));
@@ -85,7 +84,7 @@ public class AdapterHelper {
       }
       final var k = a.getKey().shortName();
       final var v = a.getValue();
-      writer.eol().append("%s    .andThenMulti(ctx.adapter(%s.class,%s))", indent, k, v);
+      writer.append("%s    .andThenMulti(ctx.adapter(%s.class,%s))", indent, k, v);
     }
 
     if (!Util.isBasicType(paramType)
@@ -94,7 +93,6 @@ public class AdapterHelper {
             .anyMatch(Constants.VALID_ANNOTATIONS::contains)) {
 
       writer
-          .eol()
           .append(
               "%s    .andThenMulti(ctx.adapter(%s.class))",
               indent,

--- a/validator-generator/src/main/java/io/avaje/validation/generator/Append.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/Append.java
@@ -1,7 +1,5 @@
 package io.avaje.validation.generator;
 
-import static io.avaje.validation.generator.ProcessingContext.useEnhancedSwitch;
-
 import java.io.IOException;
 import java.io.Writer;
 
@@ -46,7 +44,4 @@ final class Append {
     return append(String.format(format, args));
   }
 
-  public Append appendSwitchCase() {
-    return append(useEnhancedSwitch() ? " -> {" : ":");
-  }
 }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/Constants.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/Constants.java
@@ -11,6 +11,9 @@ final class Constants {
   public static final String VALID_SPI = "io.avaje.validation.spi.*";
   public static final String VALIDATOR = "io.avaje.validation.Validator";
   public static final String COMPONENT = "io.avaje.inject.Component";
+  static final String SINGLETON_JAKARTA = "jakarta.inject.Singleton";
+  static final String SINGLETON_JAVAX = "javax.inject.Singleton";
+
   public static final Set<String> VALID_ANNOTATIONS =
       Set.of(
           AvajeValidPrism.PRISM_TYPE,

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ProcessingContext.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ProcessingContext.java
@@ -28,6 +28,7 @@ final class ProcessingContext {
     private final Elements elements;
     private final Types types;
     private final int jdkVersion;
+    private final String diAnnotation;
 
     Ctx(ProcessingEnvironment env) {
       this.env = env;
@@ -36,6 +37,15 @@ final class ProcessingContext {
       this.elements = env.getElementUtils();
       this.types = env.getTypeUtils();
       this.jdkVersion = env.getSourceVersion().ordinal();
+
+      final var useComponent = elements.getTypeElement(Constants.COMPONENT) != null;
+
+      final var jakarta = elements.getTypeElement(Constants.SINGLETON_JAKARTA) != null;
+
+      diAnnotation =
+          (useComponent
+              ? Constants.COMPONENT
+              : jakarta ? Constants.SINGLETON_JAKARTA : Constants.SINGLETON_JAVAX);
     }
   }
 
@@ -45,10 +55,6 @@ final class ProcessingContext {
     CTX.set(new Ctx(processingEnv));
   }
 
-  static boolean useEnhancedSwitch() {
-    return jdkVersion() >= 14;
-  }
-
   static int jdkVersion() {
     return CTX.get().jdkVersion;
   }
@@ -56,8 +62,8 @@ final class ProcessingContext {
   static boolean isAssignable2Interface(String type, String superType) {
     return type.equals(superType)
         || Optional.ofNullable(element(type)).stream()
-        .flatMap(ProcessingContext::superTypes)
-        .anyMatch(superType::equals);
+            .flatMap(ProcessingContext::superTypes)
+            .anyMatch(superType::equals);
   }
 
   public static Stream<String> superTypes(Element element) {
@@ -105,6 +111,10 @@ final class ProcessingContext {
 
   static ProcessingEnvironment env() {
     return CTX.get().env;
+  }
+
+  static String diAnnotation() {
+    return CTX.get().diAnnotation;
   }
 
   static void clear() {

--- a/validator-generator/src/main/java/io/avaje/validation/generator/SimpleParamBeanWriter.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/SimpleParamBeanWriter.java
@@ -1,6 +1,7 @@
 package io.avaje.validation.generator;
 
 import static io.avaje.validation.generator.ProcessingContext.createWriter;
+import static io.avaje.validation.generator.ProcessingContext.diAnnotation;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -64,10 +65,10 @@ final class SimpleParamBeanWriter {
         .append(
             """
     		@Generated
-    		@Component
+    		%s
     		public final class %s implements MethodAdapterProvider {
     		""",
-            adapterShortName)
+            diAnnotation(), adapterShortName)
         .eol();
   }
 

--- a/validator-generator/src/main/java/io/avaje/validation/generator/SimpleParamBeanWriter.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/SimpleParamBeanWriter.java
@@ -14,7 +14,6 @@ final class SimpleParamBeanWriter {
   private final String adapterPackage;
   private final String adapterFullName;
   private Append writer;
-  private static boolean writeAspect = true;
 
   SimpleParamBeanWriter(ValidMethodReader beanReader) {
     this.beanReader = beanReader;
@@ -53,7 +52,7 @@ final class SimpleParamBeanWriter {
   }
 
   private void writeImports() {
-    beanReader.writeImports(writer, writeAspect);
+    beanReader.writeImports(writer);
   }
 
   private void writePackage() {
@@ -61,15 +60,15 @@ final class SimpleParamBeanWriter {
   }
 
   private void writeClassStart() {
-    writer.append("@Generated").eol();
-    writer.append("@Component").eol();
-    if (writeAspect) {
-      writer.append("@Component.Import(AOPMethodValidator.class)").eol();
-      writeAspect = false;
-    }
-
-    writer.append("public final class %s implements MethodAdapterProvider", adapterShortName);
-    writer.append("{").eol().eol();
+    writer
+        .append(
+            """
+    		@Generated
+    		@Component
+    		public final class %s implements MethodAdapterProvider {
+    		""",
+            adapterShortName)
+        .eol();
   }
 
   private void writeMethods() {

--- a/validator-generator/src/main/java/io/avaje/validation/generator/SimpleParamBeanWriter.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/SimpleParamBeanWriter.java
@@ -65,10 +65,10 @@ final class SimpleParamBeanWriter {
         .append(
             """
     		@Generated
-    		%s
+    		@%s
     		public final class %s implements MethodAdapterProvider {
     		""",
-            diAnnotation(), adapterShortName)
+            Util.shortName(diAnnotation()), adapterShortName)
         .eol();
   }
 

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ValidMethodReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ValidMethodReader.java
@@ -1,6 +1,7 @@
 package io.avaje.validation.generator;
 
 import static java.util.stream.Collectors.joining;
+import static io.avaje.validation.generator.ProcessingContext.diAnnotation;
 
 import java.util.List;
 import java.util.Set;
@@ -24,7 +25,7 @@ final class ValidMethodReader {
     this.params = element.getParameters();
     importTypes.add(type);
     importTypes.add("java.util.List");
-    importTypes.add(Constants.COMPONENT);
+    importTypes.add(diAnnotation());
     importTypes.add("java.util.Set");
     importTypes.add("java.util.Map");
     importTypes.add("io.avaje.validation.inject.aspect.MethodAdapterProvider");

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ValidMethodReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ValidMethodReader.java
@@ -44,16 +44,12 @@ final class ValidMethodReader {
     if (Util.validImportType(type)) {
       importTypes.add(type);
     }
-
     paramAnnotations.forEach(a -> a.addImports(importTypes));
     returnElementAnnotation.addImports(importTypes);
     return importTypes;
   }
 
-  public void writeImports(Append writer, boolean writeAspect) {
-    if (writeAspect) {
-      importTypes.add("io.avaje.validation.inject.aspect.AOPMethodValidator");
-    }
+  public void writeImports(Append writer) {
     for (final String importType : importTypes()) {
       if (Util.validImportType(importType)) {
         writer.append("import %s;", importType).eol();

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ValidationProcessor.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ValidationProcessor.java
@@ -259,7 +259,7 @@ public final class ValidationProcessor extends AbstractProcessor {
           .map(m -> m.getAnnotationType().toString())
           .noneMatch(s -> s.contains("Singleton") || s.contains("Component"))) {
         throw new IllegalStateException(
-            "The ValidateMethod Annotation can only be used with JSR-330 Injectable Classes");
+            "The ValidMethod Annotation can only be used with JSR-330 Injectable Classes");
       }
       writeParamProvider(executableElement);
     }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ValidationProcessor.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ValidationProcessor.java
@@ -252,15 +252,14 @@ public final class ValidationProcessor extends AbstractProcessor {
   }
 
   private void writeParamProviderForMethod(Set<ExecutableElement> elements) {
-    if (element(ComponentPrism.PRISM_TYPE) == null) {
-      throw new IllegalStateException("ValidateMethod can only be used with Avaje Inject Beans");
-    }
+
     for (final ExecutableElement executableElement : elements) {
 
       if (executableElement.getEnclosingElement().getAnnotationMirrors().stream()
           .map(m -> m.getAnnotationType().toString())
           .noneMatch(s -> s.contains("Singleton") || s.contains("Component"))) {
-        throw new IllegalStateException("ValidateMethod can only be used with Avaje Inject Beans");
+        throw new IllegalStateException(
+            "The ValidateMethod Annotation can only be used with JSR-330 Injectable Classes");
       }
       writeParamProvider(executableElement);
     }

--- a/validator-inject-plugin/src/main/java/io/avaje/validation/inject/aspect/ParamInterceptor.java
+++ b/validator-inject-plugin/src/main/java/io/avaje/validation/inject/aspect/ParamInterceptor.java
@@ -1,32 +1,29 @@
 package io.avaje.validation.inject.aspect;
 
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import io.avaje.inject.aop.Invocation;
 import io.avaje.inject.aop.MethodInterceptor;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidationContext;
 
-public class ParamInterceptor implements MethodInterceptor {
+final class ParamInterceptor implements MethodInterceptor {
 
-  private final List<ValidationAdapter<Object>> paramValidationAdapter;
-  private final ValidationAdapter<Object> returnValidationAdapter;
-  private final ValidationContext ctx;
+  private List<ValidationAdapter<Object>> paramValidationAdapter;
+  private ValidationAdapter<Object> returnValidationAdapter;
+  private ValidationContext ctx;
   private final Locale locale;
   private final boolean throwOnParamFailure;
+  private final Method method;
 
-  public ParamInterceptor(
-      Locale locale,
-      ValidationContext ctx,
-      MethodAdapterProvider methodAdapterProvider,
-      boolean throwOnParamFailure) {
+  public ParamInterceptor(Locale locale, Method method, boolean throwOnParamFailure) {
 
     this.locale = locale;
-    this.ctx = ctx;
-    this.paramValidationAdapter = methodAdapterProvider.paramAdapters(ctx);
-    this.returnValidationAdapter = methodAdapterProvider.returnAdapter(ctx);
     this.throwOnParamFailure = throwOnParamFailure;
+    this.method = method;
   }
 
   @Override
@@ -48,5 +45,13 @@ public class ParamInterceptor implements MethodInterceptor {
     returnValidationAdapter.validate(invocation.invoke(), req);
 
     req.throwWithViolations();
+  }
+
+  public void postConstruct(ValidationContext ctx, Map<Method, MethodAdapterProvider> providerMap) {
+
+    final var methodAdapterProvider = providerMap.get(method);
+    this.ctx = ctx;
+    this.paramValidationAdapter = methodAdapterProvider.paramAdapters(ctx);
+    this.returnValidationAdapter = methodAdapterProvider.returnAdapter(ctx);
   }
 }

--- a/validator-inject-plugin/src/main/java/io/avaje/validation/inject/spi/DefaultValidatorProvider.java
+++ b/validator-inject-plugin/src/main/java/io/avaje/validation/inject/spi/DefaultValidatorProvider.java
@@ -61,13 +61,13 @@ public final class DefaultValidatorProvider implements io.avaje.inject.spi.Plugi
               .forEach(validator::addLocales);
 
           props
-              .get("validation.temporal.value")
+              .get("validation.temporal.tolerance.value")
               .map(Long::valueOf)
               .ifPresent(
                   l -> {
                     final var unit =
                         props
-                            .get("validation.temporal.chronoUnit")
+                            .get("validation.temporal.tolerance.chronoUnit")
                             .map(ChronoUnit::valueOf)
                             .orElse(ChronoUnit.MILLIS);
                     validator.temporalTolerance(Duration.of(l, unit));

--- a/validator-inject-plugin/src/test/java/io/avaje/validation/inject/aspect/TestMethodValidation.java
+++ b/validator-inject-plugin/src/test/java/io/avaje/validation/inject/aspect/TestMethodValidation.java
@@ -1,5 +1,6 @@
 package io.avaje.validation.inject.aspect;
 
+import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -19,9 +20,12 @@ class TestMethodValidation {
   @BeforeAll
   static void setUpBeforeClass() throws Exception {
 
-    final var val =
-        new AOPMethodValidator(Validator.builder().build(), List.of(new TestParamProvider()));
+    final var val = new AOPMethodValidator();
     proxy = new MethodTest$Proxy(val);
+    val.post(
+        Validator.builder().build().getContext(),
+        List.of(new TestParamProvider()).stream()
+            .collect(toMap(MethodAdapterProvider::provide, p -> p)));
   }
 
   @Test

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -24,7 +24,15 @@
       <artifactId>avaje-validator-http-plugin</artifactId>
       <version>${project.version}</version>
     </dependency>
-
+    
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-inject</artifactId>
+      <version>${inject.version}</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    
     <dependency>
       <groupId>jakarta.validation</groupId>
       <artifactId>jakarta.validation-api</artifactId>

--- a/validator/src/main/java/io/avaje/validation/ValidMethod.java
+++ b/validator/src/main/java/io/avaje/validation/ValidMethod.java
@@ -1,4 +1,4 @@
-package io.avaje.validation.inject.aspect;
+package io.avaje.validation;
 
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -8,12 +8,11 @@ import java.lang.annotation.Target;
 
 import io.avaje.inject.aop.Aspect;
 
-@Deprecated
 @Aspect
 @Target(METHOD)
 @Retention(RUNTIME)
 /** Place on a method to execute validations on the parameters and return types */
-public @interface ValidateMethod {
+public @interface ValidMethod {
   String locale() default "";
 
   boolean throwOnParamFailure() default false;

--- a/validator/src/main/java/module-info.java
+++ b/validator/src/main/java/module-info.java
@@ -4,6 +4,7 @@ module io.avaje.validation {
   exports io.avaje.validation.spi;
 
   requires io.avaje.lang;
+  requires static io.avaje.inject;
 
   uses io.avaje.validation.Validator.GeneratedComponent;
   uses io.avaje.validation.spi.MessageInterpolator;


### PR DESCRIPTION
Now there is no situation where a method validator can be initialized without all the MethodAdapters


- use PostContruct to configure the Method Validator
- start opening up method validation for non-avaje projects (we'll need to deploy this and get it into the next one)

Relies on https://github.com/avaje/avaje-inject/pull/369 