### PR TITLE
Don't immediately throw for validation errors

### DIFF
--- a/blackbox-test/pom.xml
+++ b/blackbox-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-validator-parent</artifactId>
-    <version>0.12</version>
+    <version>0.13</version>
   </parent>
 
   <artifactId>validator-blackbox-test</artifactId>
@@ -35,6 +35,11 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-validator</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-validator-http-plugin</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/blackbox-test/src/test/java/example/avaje/ACustomerMessageTest.java
+++ b/blackbox-test/src/test/java/example/avaje/ACustomerMessageTest.java
@@ -74,14 +74,12 @@ class ACustomerMessageTest {
   }
 
   ConstraintViolation one(Object any, Locale locale) {
-    try {
-      validator.validate(any, locale);
-      fail("not expected");
-      return null;
-    } catch (ConstraintViolationException e) {
-      var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(1);
-      return violations.get(0);
-    }
+
+    final var violations = new ArrayList<>(validator.validate(any, locale));
+
+    if (violations.isEmpty()) throw new IllegalStateException();
+
+    assertThat(violations).hasSize(1);
+    return violations.get(0);
   }
 }

--- a/blackbox-test/src/test/java/example/avaje/AMyEmailTest.java
+++ b/blackbox-test/src/test/java/example/avaje/AMyEmailTest.java
@@ -38,14 +38,12 @@ class AMyEmailTest {
   }
 
   ConstraintViolation one(Object any, Locale locale) {
-    try {
-      validator.validate(any, locale);
-      fail("not expected");
-      return null;
-    } catch (ConstraintViolationException e) {
-      var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(1);
-      return violations.get(0);
-    }
+
+    final var violations = new ArrayList<>(validator.validate(any, locale));
+
+    if (violations.isEmpty()) throw new IllegalStateException();
+
+    assertThat(violations).hasSize(1);
+    return violations.get(0);
   }
 }

--- a/blackbox-test/src/test/java/example/avaje/AMyMinNumbersTest.java
+++ b/blackbox-test/src/test/java/example/avaje/AMyMinNumbersTest.java
@@ -84,14 +84,12 @@ class AMyMinNumbersTest {
   }
 
   ConstraintViolation one(Object any, Locale locale) {
-    try {
-      validator.validate(any, locale);
-      fail("not expected");
-      return null;
-    } catch (ConstraintViolationException e) {
-      var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(1);
-      return violations.get(0);
-    }
+
+    final var violations = new ArrayList<>(validator.validate(any, locale));
+
+    if (violations.isEmpty()) throw new IllegalStateException();
+
+    assertThat(violations).hasSize(1);
+    return violations.get(0);
   }
 }

--- a/blackbox-test/src/test/java/example/avaje/AMyNumbersTest.java
+++ b/blackbox-test/src/test/java/example/avaje/AMyNumbersTest.java
@@ -19,61 +19,61 @@ class AMyNumbersTest {
 
   @Test
   void valid() {
-    var bean = new AMyNumbers(ONE, ONE);
+    final var bean = new AMyNumbers(ONE, ONE);
     validator.validate(bean);
   }
 
   @Test
   void validDouble() {
-    var bean = new AMyNumbers(1d, 1d);
+    final var bean = new AMyNumbers(1d, 1d);
     validator.validate(bean);
   }
 
   @Test
   void decimalMax() {
-    var violation = one(new AMyNumbers(new BigDecimal("11"), ONE));
+    final var violation = one(new AMyNumbers(new BigDecimal("11"), ONE));
     assertThat(violation.message()).isEqualTo("must be less than or equal to 10.50");
   }
 
   @Test
   void decimalMaxDE() {
-    var violation = one(new AMyNumbers(new BigDecimal("11"), ONE), Locale.GERMAN);
+    final var violation = one(new AMyNumbers(new BigDecimal("11"), ONE), Locale.GERMAN);
     assertThat(violation.message()).isEqualTo("muss kleiner oder gleich 10.50 sein");
   }
 
   @Test
   void decimalMaxExclusive() {
-    var violation = one(new AMyNumbers(ONE, new BigDecimal("11")));
+    final var violation = one(new AMyNumbers(ONE, new BigDecimal("11")));
     assertThat(violation.message()).isEqualTo("must be less than 9.30");
   }
 
   @Test
   void decimalMaxExclusiveDE() {
-    var violation = one(new AMyNumbers(ONE, new BigDecimal("11")), Locale.GERMAN);
+    final var violation = one(new AMyNumbers(ONE, new BigDecimal("11")), Locale.GERMAN);
     assertThat(violation.message()).isEqualTo("muss kleiner 9.30 sein");
   }
 
   @Test
   void doubleDecimalMax() {
-    var violation = one(new AMyNumbers(11d, 1d));
+    final var violation = one(new AMyNumbers(11d, 1d));
     assertThat(violation.message()).isEqualTo("must be less than or equal to 9.50");
   }
 
   @Test
   void doubleDecimalMaxDE() {
-    var violation = one(new AMyNumbers(11d, 1d), Locale.GERMAN);
+    final var violation = one(new AMyNumbers(11d, 1d), Locale.GERMAN);
     assertThat(violation.message()).isEqualTo("muss kleiner oder gleich 9.50 sein");
   }
 
   @Test
   void doubleDecimalMaxExclusive() {
-    var violation = one(new AMyNumbers(1d, 11d));
+    final var violation = one(new AMyNumbers(1d, 11d));
     assertThat(violation.message()).isEqualTo("must be less than 8.30");
   }
 
   @Test
   void doubleDecimalMaxExclusiveDE() {
-    var violation = one(new AMyNumbers(1d, 11d), Locale.GERMAN);
+    final var violation = one(new AMyNumbers(1d, 11d), Locale.GERMAN);
     assertThat(violation.message()).isEqualTo("muss kleiner 8.30 sein");
   }
 
@@ -82,14 +82,12 @@ class AMyNumbersTest {
   }
 
   ConstraintViolation one(Object any, Locale locale) {
-    try {
-      validator.validate(any, locale);
-      fail("not expected");
-      return null;
-    } catch (ConstraintViolationException e) {
-      var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(1);
-      return violations.get(0);
-    }
+
+    final var violations = new ArrayList<>(validator.validate(any, locale));
+
+    if (violations.isEmpty()) throw new IllegalStateException();
+
+    assertThat(violations).hasSize(1);
+    return violations.get(0);
   }
 }

--- a/blackbox-test/src/test/java/example/avaje/AMyPatternTest.java
+++ b/blackbox-test/src/test/java/example/avaje/AMyPatternTest.java
@@ -38,14 +38,12 @@ class AMyPatternTest {
   }
 
   ConstraintViolation one(Object any, Locale locale) {
-    try {
-      validator.validate(any, locale);
-      fail("not expected");
-      return null;
-    } catch (ConstraintViolationException e) {
-      var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(1);
-      return violations.get(0);
-    }
+
+    final var violations = new ArrayList<>(validator.validate(any, locale));
+
+    if (violations.isEmpty()) throw new IllegalStateException();
+
+    assertThat(violations).hasSize(1);
+    return violations.get(0);
   }
 }

--- a/blackbox-test/src/test/java/example/avaje/ANumsTest.java
+++ b/blackbox-test/src/test/java/example/avaje/ANumsTest.java
@@ -125,14 +125,12 @@ class ANumsTest {
   }
 
   ConstraintViolation one(Object any, Locale locale) {
-    try {
-      validator.validate(any, locale);
-      fail("not expected");
-      return null;
-    } catch (ConstraintViolationException e) {
-      var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(1);
-      return violations.get(0);
-    }
+
+    final var violations = new ArrayList<>(validator.validate(any, locale));
+
+    if (violations.isEmpty()) throw new IllegalStateException();
+
+    assertThat(violations).hasSize(1);
+    return violations.get(0);
   }
 }

--- a/blackbox-test/src/test/java/example/avaje/APastFutureTest.java
+++ b/blackbox-test/src/test/java/example/avaje/APastFutureTest.java
@@ -93,14 +93,12 @@ class APastFutureTest {
   }
 
   ConstraintViolation one(Object any, Locale locale) {
-    try {
-      validator.validate(any, locale);
-      fail("not expected");
-      return null;
-    } catch (ConstraintViolationException e) {
-      var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(1);
-      return violations.get(0);
-    }
+
+    final var violations = new ArrayList<>(validator.validate(any, locale));
+
+    if (violations.isEmpty()) throw new IllegalStateException();
+
+    assertThat(violations).hasSize(1);
+    return violations.get(0);
   }
 }

--- a/blackbox-test/src/test/java/example/avaje/composable/SansComposableTest.java
+++ b/blackbox-test/src/test/java/example/avaje/composable/SansComposableTest.java
@@ -35,12 +35,7 @@ class SansComposableTest {
   }
 
   Set<ConstraintViolation> violations(Object any) {
-    try {
-      validator.validate(any);
-      fail("not expected");
-      return null;
-    } catch (final ConstraintViolationException e) {
-      return e.violations();
-    }
+
+    return validator.validate(any);
   }
 }

--- a/blackbox-test/src/test/java/example/avaje/nested/ANestedTest.java
+++ b/blackbox-test/src/test/java/example/avaje/nested/ANestedTest.java
@@ -14,34 +14,31 @@ class ANestedTest {
 
   @Test
   void validateNested() {
-    var contact = new AContact("Rob", "TooLargeForHere");
+    final var contact = new AContact("Rob", "TooLargeForHere");
     contact.address = new AAddress("", "TooBigHere", -1);
 
-    try {
-      validator.validate(contact);
-    } catch (ConstraintViolationException e) {
-      var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(4);
+    final var violations = new ArrayList<>(validator.validate(contact));
 
-      var v0 = violations.get(0);
-      assertThat(v0.path()).isEqualTo("");
-      assertThat(v0.propertyName()).isEqualTo("lastName");
-      assertThat(v0.message()).isEqualTo("size must be between 0 and 5");
+    assertThat(violations).hasSize(4);
 
-      var v1 = violations.get(1);
-      assertThat(v1.path()).isEqualTo("address");
-      assertThat(v1.propertyName()).isEqualTo("line1");
-      assertThat(v1.message()).isEqualTo("must not be blank");
+    final var v0 = violations.get(0);
+    assertThat(v0.path()).isEmpty();
+    assertThat(v0.propertyName()).isEqualTo("lastName");
+    assertThat(v0.message()).isEqualTo("size must be between 0 and 5");
 
-      var v2 = violations.get(2);
-      assertThat(v2.path()).isEqualTo("address");
-      assertThat(v2.propertyName()).isEqualTo("line2");
-      assertThat(v2.message()).isEqualTo("size must be between 0 and 4");
+    final var v1 = violations.get(1);
+    assertThat(v1.path()).isEqualTo("address");
+    assertThat(v1.propertyName()).isEqualTo("line1");
+    assertThat(v1.message()).isEqualTo("must not be blank");
 
-      var v3 = violations.get(3);
-      assertThat(v3.path()).isEqualTo("address");
-      assertThat(v3.propertyName()).isEqualTo("longValue");
-      assertThat(v3.message()).isEqualTo("must be greater than 0");
-    }
+    final var v2 = violations.get(2);
+    assertThat(v2.path()).isEqualTo("address");
+    assertThat(v2.propertyName()).isEqualTo("line2");
+    assertThat(v2.message()).isEqualTo("size must be between 0 and 4");
+
+    final var v3 = violations.get(3);
+    assertThat(v3.path()).isEqualTo("address");
+    assertThat(v3.propertyName()).isEqualTo("longValue");
+    assertThat(v3.message()).isEqualTo("must be greater than 0");
   }
 }

--- a/blackbox-test/src/test/java/example/avaje/nested/ANestedWithNullableTest.java
+++ b/blackbox-test/src/test/java/example/avaje/nested/ANestedWithNullableTest.java
@@ -1,12 +1,12 @@
 package example.avaje.nested;
 
-import io.avaje.validation.ConstraintViolationException;
-import io.avaje.validation.Validator;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.Validator;
 
 class ANestedWithNullableTest {
 
@@ -14,70 +14,61 @@ class ANestedWithNullableTest {
 
   @Test
   void validateNestedSkipNullAddress() {
-    var contact = new AContactWithNullable("Rob", "TooLargeForHere");
+    final var contact = new AContactWithNullable("Rob", "TooLargeForHere");
     contact.address = null;
 
-    try {
-      validator.validate(contact);
-    } catch (ConstraintViolationException e) {
-      var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(1);
+    final var violations = new ArrayList<>(validator.validate(contact));
 
-      var v0 = violations.get(0);
-      assertThat(v0.path()).isEqualTo("");
-      assertThat(v0.propertyName()).isEqualTo("lastName");
-      assertThat(v0.message()).isEqualTo("size must be between 0 and 5");
-    }
+    assertThat(violations).hasSize(1);
+
+    final var v0 = violations.get(0);
+    assertThat(v0.path()).isEmpty();
+    assertThat(v0.propertyName()).isEqualTo("lastName");
+    assertThat(v0.message()).isEqualTo("size must be between 0 and 5");
   }
 
   @Test
   void validateNestedAddress() {
-    var contact = new AContactWithNullable("Rob", "TooLargeForHere");
+    final var contact = new AContactWithNullable("Rob", "TooLargeForHere");
     contact.address = new AAddress("line1", "ok", 12);
 
-    try {
-      validator.validate(contact);
-    } catch (ConstraintViolationException e) {
-      var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(1);
+    final var violations = new ArrayList<>(validator.validate(contact));
 
-      var v0 = violations.get(0);
-      assertThat(v0.path()).isEqualTo("");
-      assertThat(v0.propertyName()).isEqualTo("lastName");
-      assertThat(v0.message()).isEqualTo("size must be between 0 and 5");
-    }
+    assertThat(violations).hasSize(1);
+
+    final var v0 = violations.get(0);
+    assertThat(v0.path()).isEmpty();
+    assertThat(v0.propertyName()).isEqualTo("lastName");
+    assertThat(v0.message()).isEqualTo("size must be between 0 and 5");
   }
 
   @Test
   void validateNested() {
-    var contact = new AContactWithNullable("Rob", "TooLargeForHere");
+    final var contact = new AContactWithNullable("Rob", "TooLargeForHere");
     contact.address = new AAddress("", "TooBigHere", -1);
 
-    try {
-      validator.validate(contact);
-    } catch (ConstraintViolationException e) {
-      var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(4);
+    final var violations = new ArrayList<>(validator.validate(contact));
 
-      var v0 = violations.get(0);
-      assertThat(v0.path()).isEqualTo("");
-      assertThat(v0.propertyName()).isEqualTo("lastName");
-      assertThat(v0.message()).isEqualTo("size must be between 0 and 5");
+    assertThat(violations).hasSize(4);
 
-      var v1 = violations.get(1);
-      assertThat(v1.path()).isEqualTo("address");
-      assertThat(v1.propertyName()).isEqualTo("line1");
-      assertThat(v1.message()).isEqualTo("must not be blank");
+    final var v0 = violations.get(0);
+    assertThat(v0.path()).isEmpty();
+    assertThat(v0.propertyName()).isEqualTo("lastName");
+    assertThat(v0.message()).isEqualTo("size must be between 0 and 5");
 
-      var v2 = violations.get(2);
-      assertThat(v2.path()).isEqualTo("address");
-      assertThat(v2.propertyName()).isEqualTo("line2");
-      assertThat(v2.message()).isEqualTo("size must be between 0 and 4");
+    final var v1 = violations.get(1);
+    assertThat(v1.path()).isEqualTo("address");
+    assertThat(v1.propertyName()).isEqualTo("line1");
+    assertThat(v1.message()).isEqualTo("must not be blank");
 
-      var v3 = violations.get(3);
-      assertThat(v3.path()).isEqualTo("address");
-      assertThat(v3.propertyName()).isEqualTo("longValue");
-      assertThat(v3.message()).isEqualTo("must be greater than 0");
-    }
+    final var v2 = violations.get(2);
+    assertThat(v2.path()).isEqualTo("address");
+    assertThat(v2.propertyName()).isEqualTo("line2");
+    assertThat(v2.message()).isEqualTo("size must be between 0 and 4");
+
+    final var v3 = violations.get(3);
+    assertThat(v3.path()).isEqualTo("address");
+    assertThat(v3.propertyName()).isEqualTo("longValue");
+    assertThat(v3.message()).isEqualTo("must be greater than 0");
   }
 }

--- a/blackbox-test/src/test/java/example/avaje/optional/OptionalTest.java
+++ b/blackbox-test/src/test/java/example/avaje/optional/OptionalTest.java
@@ -2,20 +2,16 @@ package example.avaje.optional;
 
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
-import example.avaje.composable.Sans;
 import io.avaje.validation.ConstraintViolation;
-import io.avaje.validation.ConstraintViolationException;
 import io.avaje.validation.Validator;
 
 class OptionalTest {
@@ -62,12 +58,6 @@ class OptionalTest {
   }
 
   Set<String> violations(Object any) {
-    try {
-      validator.validate(any);
-      fail("not expected");
-      return null;
-    } catch (final ConstraintViolationException e) {
-      return e.violations().stream().map(ConstraintViolation::message).collect(toSet());
-    }
+    return validator.validate(any).stream().map(ConstraintViolation::message).collect(toSet());
   }
 }

--- a/blackbox-test/src/test/java/example/avaje/typeuse/ShipTypeUseTest.java
+++ b/blackbox-test/src/test/java/example/avaje/typeuse/ShipTypeUseTest.java
@@ -38,14 +38,12 @@ class ShipTypeUseTest {
   }
 
   ConstraintViolation one(Object any) {
-    try {
-      validator.validate(any);
-      fail("not expected");
-      return null;
-    } catch (final ConstraintViolationException e) {
-      final var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(1);
-      return violations.get(0);
-    }
+
+    final var violations = new ArrayList<>(validator.validate(any));
+
+    if (violations.isEmpty()) throw new IllegalStateException();
+
+    assertThat(violations).hasSize(1);
+    return violations.get(0);
   }
 }

--- a/blackbox-test/src/test/java/example/jakarta/AllSortsBeanTest.java
+++ b/blackbox-test/src/test/java/example/jakarta/AllSortsBeanTest.java
@@ -14,15 +14,14 @@ class AllSortsBeanTest {
 
   final Validator validator = Validator.builder().addLocales(Locale.GERMAN).build();
 
-  protected ConstraintViolation one(AllSortsBean pojo, Locale locale) {
-    try {
-      validator.validate(pojo, locale);
-      throw new IllegalStateException("don't get here");
-    } catch (ConstraintViolationException e) {
-      var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(1);
-      return violations.get(0);
-    }
+  ConstraintViolation one(Object any, Locale locale) {
+
+    final var violations = new ArrayList<>(validator.validate(any, locale));
+
+    if (violations.isEmpty()) throw new IllegalStateException();
+
+    assertThat(violations).hasSize(1);
+    return violations.get(0);
   }
 
   @Test

--- a/blackbox-test/src/test/java/example/jakarta/JCustomerMessageTest.java
+++ b/blackbox-test/src/test/java/example/jakarta/JCustomerMessageTest.java
@@ -74,14 +74,12 @@ class JCustomerMessageTest {
   }
 
   ConstraintViolation one(Object any, Locale locale) {
-    try {
-      validator.validate(any, locale);
-      fail("not expected");
-      return null;
-    } catch (ConstraintViolationException e) {
-      var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(1);
-      return violations.get(0);
-    }
+
+    final var violations = new ArrayList<>(validator.validate(any, locale));
+
+    if (violations.isEmpty()) throw new IllegalStateException();
+
+    assertThat(violations).hasSize(1);
+    return violations.get(0);
   }
 }

--- a/blackbox-test/src/test/java/example/jakarta/JMyEmailTest.java
+++ b/blackbox-test/src/test/java/example/jakarta/JMyEmailTest.java
@@ -38,14 +38,12 @@ class JMyEmailTest {
   }
 
   ConstraintViolation one(Object any, Locale locale) {
-    try {
-      validator.validate(any, locale);
-      fail("not expected");
-      return null;
-    } catch (ConstraintViolationException e) {
-      var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(1);
-      return violations.get(0);
-    }
+
+    final var violations = new ArrayList<>(validator.validate(any, locale));
+
+    if (violations.isEmpty()) throw new IllegalStateException();
+
+    assertThat(violations).hasSize(1);
+    return violations.get(0);
   }
 }

--- a/blackbox-test/src/test/java/example/jakarta/JMyMinNumbersTest.java
+++ b/blackbox-test/src/test/java/example/jakarta/JMyMinNumbersTest.java
@@ -84,14 +84,12 @@ class JMyMinNumbersTest {
   }
 
   ConstraintViolation one(Object any, Locale locale) {
-    try {
-      validator.validate(any, locale);
-      fail("not expected");
-      return null;
-    } catch (ConstraintViolationException e) {
-      var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(1);
-      return violations.get(0);
-    }
+
+    final var violations = new ArrayList<>(validator.validate(any, locale));
+
+    if (violations.isEmpty()) throw new IllegalStateException();
+
+    assertThat(violations).hasSize(1);
+    return violations.get(0);
   }
 }

--- a/blackbox-test/src/test/java/example/jakarta/JMyNumbersTest.java
+++ b/blackbox-test/src/test/java/example/jakarta/JMyNumbersTest.java
@@ -19,61 +19,61 @@ class JMyNumbersTest {
 
   @Test
   void valid() {
-    var bean = new JMyNumbers(ONE, ONE);
+    final var bean = new JMyNumbers(ONE, ONE);
     validator.validate(bean);
   }
 
   @Test
   void validDouble() {
-    var bean = new JMyNumbers(1d, 1d);
+    final var bean = new JMyNumbers(1d, 1d);
     validator.validate(bean);
   }
 
   @Test
   void decimalMax() {
-    var violation = one(new JMyNumbers(new BigDecimal("11"), ONE));
+    final var violation = one(new JMyNumbers(new BigDecimal("11"), ONE));
     assertThat(violation.message()).isEqualTo("must be less than or equal to 10.50");
   }
 
   @Test
   void decimalMaxDE() {
-    var violation = one(new JMyNumbers(new BigDecimal("11"), ONE), Locale.GERMAN);
+    final var violation = one(new JMyNumbers(new BigDecimal("11"), ONE), Locale.GERMAN);
     assertThat(violation.message()).isEqualTo("muss kleiner oder gleich 10.50 sein");
   }
 
   @Test
   void decimalMaxExclusive() {
-    var violation = one(new JMyNumbers(ONE, new BigDecimal("11")));
+    final var violation = one(new JMyNumbers(ONE, new BigDecimal("11")));
     assertThat(violation.message()).isEqualTo("must be less than 9.30");
   }
 
   @Test
   void decimalMaxExclusiveDE() {
-    var violation = one(new JMyNumbers(ONE, new BigDecimal("11")), Locale.GERMAN);
+    final var violation = one(new JMyNumbers(ONE, new BigDecimal("11")), Locale.GERMAN);
     assertThat(violation.message()).isEqualTo("muss kleiner 9.30 sein");
   }
 
   @Test
   void doubleDecimalMax() {
-    var violation = one(new JMyNumbers(11d, 1d));
+    final var violation = one(new JMyNumbers(11d, 1d));
     assertThat(violation.message()).isEqualTo("must be less than or equal to 9.50");
   }
 
   @Test
   void doubleDecimalMaxDE() {
-    var violation = one(new JMyNumbers(11d, 1d), Locale.GERMAN);
+    final var violation = one(new JMyNumbers(11d, 1d), Locale.GERMAN);
     assertThat(violation.message()).isEqualTo("muss kleiner oder gleich 9.50 sein");
   }
 
   @Test
   void doubleDecimalMaxExclusive() {
-    var violation = one(new JMyNumbers(1d, 11d));
+    final var violation = one(new JMyNumbers(1d, 11d));
     assertThat(violation.message()).isEqualTo("must be less than 8.30");
   }
 
   @Test
   void doubleDecimalMaxExclusiveDE() {
-    var violation = one(new JMyNumbers(1d, 11d), Locale.GERMAN);
+    final var violation = one(new JMyNumbers(1d, 11d), Locale.GERMAN);
     assertThat(violation.message()).isEqualTo("muss kleiner 8.30 sein");
   }
 
@@ -82,14 +82,12 @@ class JMyNumbersTest {
   }
 
   ConstraintViolation one(Object any, Locale locale) {
-    try {
-      validator.validate(any, locale);
-      fail("not expected");
-      return null;
-    } catch (ConstraintViolationException e) {
-      var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(1);
-      return violations.get(0);
-    }
+
+    final var violations = new ArrayList<>(validator.validate(any, locale));
+
+    if (violations.isEmpty()) throw new IllegalStateException();
+
+    assertThat(violations).hasSize(1);
+    return violations.get(0);
   }
 }

--- a/blackbox-test/src/test/java/example/jakarta/JMyPatternTest.java
+++ b/blackbox-test/src/test/java/example/jakarta/JMyPatternTest.java
@@ -17,19 +17,19 @@ class JMyPatternTest {
 
   @Test
   void valid() {
-    var bean = new JMyPattern("12");
+    final var bean = new JMyPattern("12");
     validator.validate(bean);
   }
 
   @Test
   void pattern() {
-    var violation = one(new JMyPattern("abc"));
+    final var violation = one(new JMyPattern("abc"));
     assertThat(violation.message()).isEqualTo("must match \"[0-3]+\"");
   }
 
   @Test
   void patternDE() {
-    var violation = one(new JMyPattern("abc"), Locale.GERMAN);
+    final var violation = one(new JMyPattern("abc"), Locale.GERMAN);
     assertThat(violation.message()).isEqualTo("muss mit \"[0-3]+\" übereinstimmen");
   }
 
@@ -38,14 +38,12 @@ class JMyPatternTest {
   }
 
   ConstraintViolation one(Object any, Locale locale) {
-    try {
-      validator.validate(any, locale);
-      fail("not expected");
-      return null;
-    } catch (ConstraintViolationException e) {
-      var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(1);
-      return violations.get(0);
-    }
+
+    final var violations = new ArrayList<>(validator.validate(any, locale));
+
+    if (violations.isEmpty()) throw new IllegalStateException();
+
+    assertThat(violations).hasSize(1);
+    return violations.get(0);
   }
 }

--- a/blackbox-test/src/test/java/example/jakarta/JNumsTest.java
+++ b/blackbox-test/src/test/java/example/jakarta/JNumsTest.java
@@ -24,97 +24,97 @@ class JNumsTest {
 
   @Test
   void digits() {
-    var bean = new JNums();
+    final var bean = new JNums();
     bean.digits = "12345678";
-    var violation = one(bean);
+    final var violation = one(bean);
     assertThat(violation.message()).isEqualTo("numeric value out of bounds (<5 digits>.<3 digits> expected)");
   }
 
   @Test
   void digitsDE() {
-    var bean = new JNums();
+    final var bean = new JNums();
     bean.digits = "12345678";
-    var violation = one(bean, Locale.GERMAN);
+    final var violation = one(bean, Locale.GERMAN);
     assertThat(violation.message()).isEqualTo("numerischer Wert außerhalb des gültigen Bereichs (<5 digits>.<3 digits> erwartet)");
   }
 
   @Test
   void digitsDecimal() {
-    var bean = new ANums();
+    final var bean = new ANums();
     bean.digitsDecimal = new BigDecimal("12345678");
-    var violation = one(bean);
+    final var violation = one(bean);
     assertThat(violation.message()).isEqualTo("numeric value out of bounds (<4 digits>.<2 digits> expected)");
   }
 
   @Test
   void digitsDecimalDE() {
-    var bean = new ANums();
+    final var bean = new ANums();
     bean.digitsDecimal = new BigDecimal("12345678");
-    var violation = one(bean, Locale.GERMAN);
+    final var violation = one(bean, Locale.GERMAN);
     assertThat(violation.message()).isEqualTo("numerischer Wert außerhalb des gültigen Bereichs (<4 digits>.<2 digits> erwartet)");
   }
 
   @Test
   void positive() {
-    var bean = new JNums();
+    final var bean = new JNums();
     bean.positive = -1;
-    var violation = one(bean);
+    final var violation = one(bean);
     assertThat(violation.message()).isEqualTo("must be greater than 0");
   }
 
   @Test
   void positiveDE() {
-    var bean = new JNums();
+    final var bean = new JNums();
     bean.positive = -1;
-    var violation = one(bean, Locale.GERMAN);
+    final var violation = one(bean, Locale.GERMAN);
     assertThat(violation.message()).isEqualTo("muss größer als 0 sein");
   }
 
   @Test
   void positiveOrZero() {
-    var bean = new JNums();
+    final var bean = new JNums();
     bean.positiveOrZero = -1;
-    var violation = one(bean);
+    final var violation = one(bean);
     assertThat(violation.message()).isEqualTo("must be greater than or equal to 0");
   }
 
   @Test
   void positiveOrZeroDE() {
-    var bean = new JNums();
+    final var bean = new JNums();
     bean.positiveOrZero = -1;
-    var violation = one(bean, Locale.GERMAN);
+    final var violation = one(bean, Locale.GERMAN);
     assertThat(violation.message()).isEqualTo("muss größer-gleich 0 sein");
   }
 
   @Test
   void negative() {
-    var bean = new JNums();
+    final var bean = new JNums();
     bean.negative = 1;
-    var violation = one(bean);
+    final var violation = one(bean);
     assertThat(violation.message()).isEqualTo("must be less than 0");
   }
 
   @Test
   void negativeDE() {
-    var bean = new JNums();
+    final var bean = new JNums();
     bean.negative = 1;
-    var violation = one(bean, Locale.GERMAN);
+    final var violation = one(bean, Locale.GERMAN);
     assertThat(violation.message()).isEqualTo("muss kleiner als 0 sein");
   }
 
   @Test
   void negativeOrZero() {
-    var bean = new JNums();
+    final var bean = new JNums();
     bean.negativeOrZero = 1;
-    var violation = one(bean);
+    final var violation = one(bean);
     assertThat(violation.message()).isEqualTo("must be less than or equal to 0");
   }
 
   @Test
   void negativeOrZeroDE() {
-    var bean = new JNums();
+    final var bean = new JNums();
     bean.negativeOrZero = 1;
-    var violation = one(bean, Locale.GERMAN);
+    final var violation = one(bean, Locale.GERMAN);
     assertThat(violation.message()).isEqualTo("muss kleiner-gleich 0 sein");
   }
 
@@ -123,14 +123,12 @@ class JNumsTest {
   }
 
   ConstraintViolation one(Object any, Locale locale) {
-    try {
-      validator.validate(any, locale);
-      fail("not expected");
-      return null;
-    } catch (ConstraintViolationException e) {
-      var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(1);
-      return violations.get(0);
-    }
+
+    final var violations = new ArrayList<>(validator.validate(any, locale));
+
+    if (violations.isEmpty()) throw new IllegalStateException();
+
+    assertThat(violations).hasSize(1);
+    return violations.get(0);
   }
 }

--- a/blackbox-test/src/test/java/example/jakarta/JPastFutureTest.java
+++ b/blackbox-test/src/test/java/example/jakarta/JPastFutureTest.java
@@ -93,7 +93,7 @@ class JPastFutureTest {
 
   ConstraintViolation one(Object any, Locale locale) {
     try {
-      validator.validate(any, locale);
+      ConstraintViolationException.throwWithViolations(validator.validate(any, locale));
       fail("not expected");
       return null;
     } catch (ConstraintViolationException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.avaje</groupId>
   <artifactId>avaje-validator-parent</artifactId>
-  <version>0.12</version>
+  <version>0.13</version>
 
   <packaging>pom</packaging>
   <name>validator parent</name>

--- a/validator-constraints/pom.xml
+++ b/validator-constraints/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.avaje</groupId>
 		<artifactId>avaje-validator-parent</artifactId>
-		<version>0.12</version>
+		<version>0.13</version>
 	</parent>
 	<artifactId>validator-constraints</artifactId>
 </project>

--- a/validator-generator/pom.xml
+++ b/validator-generator/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-validator-parent</artifactId>
-    <version>0.12</version>
+    <version>0.13</version>
   </parent>
 
   <artifactId>avaje-validator-generator</artifactId>

--- a/validator-http-plugin/pom.xml
+++ b/validator-http-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-validator-parent</artifactId>
-    <version>0.12</version>
+    <version>0.13</version>
   </parent>
   <artifactId>avaje-validator-http-plugin</artifactId>
   <name>validator-http-plugin</name>
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-validator</artifactId>
-      <version>0.11</version>
+      <version>0.13</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>

--- a/validator-http-plugin/src/main/java/io/avaje/validation/http/BeanValidator.java
+++ b/validator-http-plugin/src/main/java/io/avaje/validation/http/BeanValidator.java
@@ -10,7 +10,6 @@ import io.avaje.http.api.ValidationException;
 import io.avaje.inject.BeanScope;
 import io.avaje.inject.PostConstruct;
 import io.avaje.validation.ConstraintViolation;
-import io.avaje.validation.ConstraintViolationException;
 import io.avaje.validation.Validator;
 
 public class BeanValidator implements io.avaje.http.api.Validator {
@@ -27,11 +26,8 @@ public class BeanValidator implements io.avaje.http.api.Validator {
       throws ValidationException {
 
     final Locale language = resolveLocale(acceptLanguage, locales);
-    try {
-      validator.validate(bean, language, groups);
-    } catch (final ConstraintViolationException e) {
-      throwExceptionWith(e.violations());
-    }
+
+    throwExceptionWith(validator.validate(bean, language, groups));
   }
 
   @PostConstruct
@@ -40,6 +36,8 @@ public class BeanValidator implements io.avaje.http.api.Validator {
   }
 
   private void throwExceptionWith(Set<ConstraintViolation> violations) {
+
+    if (violations.isEmpty()) return;
 
     final Map<String, Object> errors = new LinkedHashMap<>();
     for (final var violation : violations) {

--- a/validator-http-plugin/src/main/java/io/avaje/validation/http/DefaultValidatorProvider.java
+++ b/validator-http-plugin/src/main/java/io/avaje/validation/http/DefaultValidatorProvider.java
@@ -38,7 +38,7 @@ public final class DefaultValidatorProvider implements io.avaje.inject.spi.Plugi
 
           final var beanValidator = new BeanValidator(locales);
 
-          builder.addPostConstructConsumerHook(beanValidator::setValidator);
+          builder.addPostConstructHooks(beanValidator::setValidator);
 
           return beanValidator;
         });

--- a/validator-inject-plugin/pom.xml
+++ b/validator-inject-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-validator-parent</artifactId>
-    <version>0.12</version>
+    <version>0.13</version>
   </parent>
   <artifactId>avaje-validator-inject-plugin</artifactId>
   <name>validator-inject-plugin</name>
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-validator</artifactId>
-      <version>0.11</version>
+      <version>0.13</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>

--- a/validator-inject-plugin/src/main/java/io/avaje/validation/inject/spi/DefaultValidatorProvider.java
+++ b/validator-inject-plugin/src/main/java/io/avaje/validation/inject/spi/DefaultValidatorProvider.java
@@ -84,7 +84,7 @@ public final class DefaultValidatorProvider implements io.avaje.inject.spi.Plugi
         () -> {
           final var methodValidator = new AOPMethodValidator();
 
-          builder.addPostConstructConsumerHook(
+          builder.addPostConstructHooks(
               b -> {
                 final var ctx = (ValidationContext) b.get(Validator.class);
                 final var map =

--- a/validator-inject-plugin/src/test/java/io/avaje/validation/inject/aspect/TestMethodValidation.java
+++ b/validator-inject-plugin/src/test/java/io/avaje/validation/inject/aspect/TestMethodValidation.java
@@ -23,7 +23,7 @@ class TestMethodValidation {
     final var val = new AOPMethodValidator();
     proxy = new MethodTest$Proxy(val);
     val.post(
-        Validator.builder().build().getContext(),
+        Validator.builder().build().context(),
         List.of(new TestParamProvider()).stream()
             .collect(toMap(MethodAdapterProvider::provide, p -> p)));
   }

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-validator-parent</artifactId>
-    <version>0.12</version>
+    <version>0.13</version>
   </parent>
 
   <artifactId>avaje-validator</artifactId>
@@ -18,13 +18,13 @@
       <artifactId>avaje-lang</artifactId>
       <version>1.0</version>
     </dependency>
-
+<!--
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-validator-http-plugin</artifactId>
       <version>${project.version}</version>
     </dependency>
-
+-->
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>

--- a/validator/src/main/java/io/avaje/validation/ConstraintViolationException.java
+++ b/validator/src/main/java/io/avaje/validation/ConstraintViolationException.java
@@ -19,4 +19,8 @@ public final class ConstraintViolationException extends RuntimeException {
   public Set<ConstraintViolation> violations() {
     return violations;
   }
+
+  public static void throwWithViolations(Set<ConstraintViolation> violations) {
+    throw new ConstraintViolationException(violations);
+  }
 }

--- a/validator/src/main/java/io/avaje/validation/Validator.java
+++ b/validator/src/main/java/io/avaje/validation/Validator.java
@@ -35,7 +35,7 @@ import java.util.function.Supplier;
 public interface Validator {
 
   /** Validate the object using the default locale. */
-  void validate(Object value, @Nullable Class<?>... groups) throws ConstraintViolationException;
+  Set<ConstraintViolation> validate(Object value, @Nullable Class<?>... groups) throws ConstraintViolationException;
 
   /**
    * Validate the object with a given locale.
@@ -44,7 +44,7 @@ public interface Validator {
    *
    * <p>This is expected to be used when the Validator is configured to support multiple locales.
    */
-  void validate(Object any, @Nullable Locale locale, @Nullable Class<?>... groups)
+  Set<ConstraintViolation> validate(Object any, @Nullable Locale locale, @Nullable Class<?>... groups)
       throws ConstraintViolationException;
 
   /** Return the validation context used to create adapters */

--- a/validator/src/main/java/io/avaje/validation/adapter/ValidationRequest.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/ValidationRequest.java
@@ -1,7 +1,9 @@
 package io.avaje.validation.adapter;
 
 import java.util.List;
+import java.util.Set;
 
+import io.avaje.validation.ConstraintViolation;
 import io.avaje.validation.ConstraintViolationException;
 
 /** A validation request. */
@@ -24,6 +26,9 @@ public interface ValidationRequest {
   /** Pop the nested property path. */
   void popPath();
 
+  Set<ConstraintViolation> violations();
+
   /** Throw ConstraintViolationException if there are violations in this request. */
   void throwWithViolations() throws ConstraintViolationException;
+
 }

--- a/validator/src/main/java/io/avaje/validation/core/DRequest.java
+++ b/validator/src/main/java/io/avaje/validation/core/DRequest.java
@@ -65,4 +65,9 @@ final class DRequest implements ValidationRequest {
   public List<Class<?>> groups() {
     return groups;
   }
+
+  @Override
+  public Set<ConstraintViolation> violations() {
+    return violations;
+  }
 }

--- a/validator/src/main/java/io/avaje/validation/core/DValidator.java
+++ b/validator/src/main/java/io/avaje/validation/core/DValidator.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import io.avaje.lang.Nullable;
+import io.avaje.validation.ConstraintViolation;
 import io.avaje.validation.Validator;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidationContext;
@@ -66,15 +67,15 @@ final class DValidator implements Validator, ValidationContext {
   }
 
   @Override
-  public void validate(Object any, @Nullable Class<?>... groups) {
-    validate(any, null, groups);
+  public Set<ConstraintViolation> validate(Object any, @Nullable Class<?>... groups) {
+    return validate(any, null, groups);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public void validate(Object any, @Nullable Locale locale, @Nullable Class<?>... groups) {
+  public Set<ConstraintViolation> validate(Object any, @Nullable Locale locale, @Nullable Class<?>... groups) {
     final var type = (ValidationType<Object>) type(any.getClass());
-    type.validate(any, locale, List.of(groups));
+    return type.validate(any, locale, List.of(groups));
   }
 
   @Override

--- a/validator/src/main/java/io/avaje/validation/core/ValidationType.java
+++ b/validator/src/main/java/io/avaje/validation/core/ValidationType.java
@@ -2,8 +2,10 @@ package io.avaje.validation.core;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import io.avaje.lang.Nullable;
+import io.avaje.validation.ConstraintViolation;
 import io.avaje.validation.ConstraintViolationException;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidationContext;
@@ -18,10 +20,14 @@ final class ValidationType<T> {
     this.adapter = adapter;
   }
 
-  public void validate(T object, @Nullable Locale locale, List<Class<?>> groups)
+  public Set<ConstraintViolation> validate(T object, @Nullable Locale locale, List<Class<?>> groups)
       throws ConstraintViolationException {
     final var req = ctx.request(locale, groups);
-    adapter.validate(object, req);
-    req.throwWithViolations();
+    try {
+      adapter.validate(object, req);
+    } catch (final ConstraintViolationException e) {
+      return e.violations();
+    }
+    return req.violations();
   }
 }

--- a/validator/src/test/java/io/avaje/validation/core/BasicTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/BasicTest.java
@@ -1,16 +1,15 @@
 package io.avaje.validation.core;
 
-import io.avaje.validation.ConstraintViolation;
-import io.avaje.validation.ConstraintViolationException;
-import io.avaje.validation.Validator;
-import io.avaje.validation.adapter.ValidationContext;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.avaje.validation.ConstraintViolation;
+import io.avaje.validation.Validator;
+import io.avaje.validation.adapter.ValidationContext;
 
 public abstract class BasicTest {
 
@@ -31,13 +30,12 @@ public abstract class BasicTest {
       new DRequest((DValidator) validator, false, null, List.of(BasicTest.class));
 
   protected ConstraintViolation one(Object pojo, Locale locale, Class<?>... groups) {
-    try {
-      validator.validate(pojo, locale, groups);
-      throw new IllegalStateException("don't get here");
-    } catch (final ConstraintViolationException e) {
-      final var violations = new ArrayList<>(e.violations());
-      assertThat(violations).hasSize(1);
-      return violations.get(0);
-    }
+
+    final var violations = new ArrayList<>(validator.validate(pojo, locale, groups));
+
+    if (violations.isEmpty()) throw new IllegalStateException();
+
+    assertThat(violations).hasSize(1);
+    return violations.get(0);
   }
 }

--- a/validator/src/test/java/io/avaje/validation/core/ValidatorTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/ValidatorTest.java
@@ -1,122 +1,104 @@
 package io.avaje.validation.core;
 
-import io.avaje.validation.ConstraintViolation;
-import io.avaje.validation.ConstraintViolationException;
-import io.avaje.validation.Validator;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.ConstraintViolation;
+import io.avaje.validation.Validator;
 
 class ValidatorTest {
 
   private final Validator validator =
       Validator.builder()
-              .add(Customer.class, CustomerValidationAdapter::new)
-              .add(Address.class, AddressValidationAdapter::new)
-              .add(Contact.class, ContactValidationAdapter::new)
-              .build();
+          .add(Customer.class, CustomerValidationAdapter::new)
+          .add(Address.class, AddressValidationAdapter::new)
+          .add(Contact.class, ContactValidationAdapter::new)
+          .build();
 
   @Test
   void testAllFail() {
-    try {
-      validator.validate(new Customer(false, null, LocalDate.now().plusDays(3)));
-      fail("");
-    } catch (ConstraintViolationException e) {
-      Set<ConstraintViolation> violations = e.violations();
-      assertThat(violations).hasSize(3);
-    }
+
+    final var violations =
+        validator.validate(new Customer(false, null, LocalDate.now().plusDays(3)));
+
+    assertThat(violations).hasSize(3);
   }
 
   @Test
   void testStrDate() {
-    try {
-      validator.validate(new Customer(true, "  ", LocalDate.now().plusDays(3)));
-    } catch (ConstraintViolationException e) {
-      Set<ConstraintViolation> violations = e.violations();
-      assertThat(violations).hasSize(2);
-    }
+
+    final Set<ConstraintViolation> violations =
+        validator.validate(new Customer(true, "  ", LocalDate.now().plusDays(3)));
+    assertThat(violations).hasSize(2);
   }
 
   @Test
   void testStrOnly() {
-    try {
-    validator.validate(new Customer(true, "  ", LocalDate.now().minusDays(3)));
-    } catch (ConstraintViolationException e) {
-      Set<ConstraintViolation> violations = e.violations();
-      assertThat(violations).hasSize(1);
-    }
+
+    final Set<ConstraintViolation> violations =
+        validator.validate(new Customer(true, "  ", LocalDate.now().minusDays(3)));
+
+    assertThat(violations).hasSize(1);
   }
 
   @Test
   void testRecurse() {
-    try {
-      var cust = new Customer(false, null, LocalDate.now().plusDays(3));
-      cust.billingAddress.line1 = null;
 
-      var c0 = new Contact();
-      var c1 = new Contact(null, "hi");
-      c1.address = new Address();
-      cust.contacts = List.of(c0, c1 , c0, c0);
-      validator.validate(cust);
-      fail("");
-    } catch (ConstraintViolationException e) {
-      Set<ConstraintViolation> violations = e.violations();
-      assertThat(violations).hasSize(7);
-      List<ConstraintViolation> asList = new ArrayList<>(violations);
+    final var cust = new Customer(false, null, LocalDate.now().plusDays(3));
+    cust.billingAddress.line1 = null;
 
-      var last = asList.get(violations.size() - 1);
-      assertThat(last.path()).isEqualTo("contacts.1.address");
-      assertThat(last.propertyName()).isEqualTo("line1");
-      assertThat(last.message()).isEqualTo("myCustomNullMessage");
-    }
+    final var c0 = new Contact();
+    final var c1 = new Contact(null, "hi");
+    c1.address = new Address();
+    cust.contacts = List.of(c0, c1, c0, c0);
+    final Set<ConstraintViolation> violations = validator.validate(cust);
+    assertThat(violations).hasSize(7);
+    final List<ConstraintViolation> asList = new ArrayList<>(violations);
+
+    final var last = asList.get(violations.size() - 1);
+    assertThat(last.path()).isEqualTo("contacts.1.address");
+    assertThat(last.propertyName()).isEqualTo("line1");
+    assertThat(last.message()).isEqualTo("myCustomNullMessage");
   }
 
   @Test
   void contactWhenLastNameNull() {
-    try {
-      var contact = new Contact("first", null);
-      validator.validate(contact);
-      fail("");
-    } catch (ConstraintViolationException e) {
-      Set<ConstraintViolation> violations = e.violations();
-      assertThat(violations).hasSize(1);
-      List<ConstraintViolation> asList = new ArrayList<>(violations);
+    final var contact = new Contact("first", null);
+    final Set<ConstraintViolation> violations = validator.validate(contact);
+    assertThat(violations).hasSize(1);
+    final List<ConstraintViolation> asList = new ArrayList<>(violations);
 
-      var first = asList.get(0);
-      assertThat(first.path()).isEqualTo("");
-      assertThat(first.propertyName()).isEqualTo("lastName");
-      assertThat(first.message()).isEqualTo("must not be null");
-    }
+    final var first = asList.get(0);
+    assertThat(first.path()).isEqualTo("");
+    assertThat(first.propertyName()).isEqualTo("lastName");
+    assertThat(first.message()).isEqualTo("must not be null");
   }
 
   @Test
   void customerWhenBillingAddressNull() {
-    try {
-      var customer = new Customer(true, " success ", LocalDate.now().minusDays(3));
-      customer.billingAddress = null;
-      validator.validate(customer);
+    final var customer = new Customer(true, " success ", LocalDate.now().minusDays(3));
+    customer.billingAddress = null;
+    final Set<ConstraintViolation> violations = validator.validate(customer);
 
-      fail("");
-    } catch (ConstraintViolationException e) {
-      Set<ConstraintViolation> violations = e.violations();
-      assertThat(violations).hasSize(1);
-      List<ConstraintViolation> asList = new ArrayList<>(violations);
+    assertThat(violations).hasSize(1);
+    final List<ConstraintViolation> asList = new ArrayList<>(violations);
 
-      var first = asList.get(0);
-      assertThat(first.path()).isEqualTo("");
-      assertThat(first.propertyName()).isEqualTo("billingAddress");
-      assertThat(first.message()).isEqualTo("must not be null");
-    }
+    final var first = asList.get(0);
+    assertThat(first.path()).isEqualTo("");
+    assertThat(first.propertyName()).isEqualTo("billingAddress");
+    assertThat(first.message()).isEqualTo("must not be null");
   }
 
   @Test
   void testSuccess() {
-    validator.validate(new Customer(true, " success ", LocalDate.now().minusDays(3)));
+    final Set<ConstraintViolation> violations =
+        validator.validate(new Customer(true, " success ", LocalDate.now().minusDays(3)));
+    assertThat(violations).hasSize(0);
   }
 }


### PR DESCRIPTION
So I'm looking at the Hibernate validation docs to see what to add in our site docs, and the group example reminded me of an older project that used validation similarly.

Basically, If you want to use groups, doing try-catch multiple times is unwieldy. 