### PR TITLE
Add Default Group

### DIFF
--- a/validator/src/main/java/io/avaje/validation/adapter/ValidationAdapter.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/ValidationAdapter.java
@@ -106,8 +106,6 @@ public interface ValidationAdapter<T> {
   default boolean checkGroups(Set<Class<?>> adapterGroups, ValidationRequest request) {
     final var requestGroups = request.groups();
 
-    if (requestGroups.isEmpty()) return true;
-
     for (final var group : requestGroups) {
       if (adapterGroups.contains(group)) {
         return true;

--- a/validator/src/main/java/io/avaje/validation/core/DRequest.java
+++ b/validator/src/main/java/io/avaje/validation/core/DRequest.java
@@ -5,10 +5,13 @@ import io.avaje.validation.ConstraintViolation;
 import io.avaje.validation.ConstraintViolationException;
 import io.avaje.validation.adapter.ValidationContext;
 import io.avaje.validation.adapter.ValidationRequest;
+import io.avaje.validation.groups.Default;
 
 import java.util.*;
 
 final class DRequest implements ValidationRequest {
+
+  private static final List<Class<?>> DEFAULT_GROUP = List.of(Default.class);
 
   private final ArrayDeque<String> pathStack = new ArrayDeque<>();
 
@@ -23,7 +26,7 @@ final class DRequest implements ValidationRequest {
     this.validator = validator;
     this.failfast = failfast;
     this.locale = locale;
-    this.groups = groups;
+    this.groups = !groups.isEmpty() ? groups : DEFAULT_GROUP;
   }
 
   private String currentPath() {

--- a/validator/src/main/java/io/avaje/validation/groups/Default.java
+++ b/validator/src/main/java/io/avaje/validation/groups/Default.java
@@ -1,0 +1,15 @@
+package io.avaje.validation.groups;
+
+/**
+ * Default Validation group.
+ *
+ * <p>Unless a list of groups is explicitly defined:
+ *
+ * <ul>
+ *   <li>constraints belong to the {@code Default} group
+ *   <li>validation applies to the {@code Default} group
+ * </ul>
+ *
+ * Most structural constraints should belong to the default group.
+ */
+public interface Default {}

--- a/validator/src/test/java/io/avaje/validation/core/ValidatorTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/ValidatorTest.java
@@ -67,7 +67,7 @@ class ValidatorTest {
       fail("");
     } catch (ConstraintViolationException e) {
       Set<ConstraintViolation> violations = e.violations();
-      assertThat(violations).hasSize(7);
+      assertThat(violations).hasSize(6);
       List<ConstraintViolation> asList = new ArrayList<>(violations);
 
       var last = asList.get(violations.size() - 1);


### PR DESCRIPTION
Adds the concept of a `Default` Group. 

Unless a list of groups is explicitly defined: 

1. constraints belong to the `Default` group
2. validation applies to the `Default` group