### PR TITLE
Update BeanValidator for ValidationException.Violation with cause

### DIFF
--- a/blackbox-test/pom.xml
+++ b/blackbox-test/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-api</artifactId>
-      <version>1.45</version>
+      <version>2.0-RC2</version>
     </dependency>
 
     <!-- test dependencies -->

--- a/blackbox-test/pom.xml
+++ b/blackbox-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-validator-parent</artifactId>
-    <version>0.15</version>
+    <version>0.16</version>
   </parent>
 
   <artifactId>validator-blackbox-test</artifactId>

--- a/blackbox-test/src/test/java/example/avaje/nested/ANestedTest.java
+++ b/blackbox-test/src/test/java/example/avaje/nested/ANestedTest.java
@@ -24,23 +24,23 @@ class ANestedTest {
       assertThat(violations).hasSize(4);
 
       var v0 = violations.get(0);
-      assertThat(v0.path()).isEqualTo("");
-      assertThat(v0.propertyName()).isEqualTo("lastName");
+      assertThat(v0.path()).isEqualTo("lastName");
+      assertThat(v0.field()).isEqualTo("lastName");
       assertThat(v0.message()).isEqualTo("size must be between 0 and 5");
 
       var v1 = violations.get(1);
-      assertThat(v1.path()).isEqualTo("address");
-      assertThat(v1.propertyName()).isEqualTo("line1");
+      assertThat(v1.path()).isEqualTo("address.line1");
+      assertThat(v1.field()).isEqualTo("line1");
       assertThat(v1.message()).isEqualTo("must not be blank");
 
       var v2 = violations.get(2);
-      assertThat(v2.path()).isEqualTo("address");
-      assertThat(v2.propertyName()).isEqualTo("line2");
+      assertThat(v2.path()).isEqualTo("address.line2");
+      assertThat(v2.field()).isEqualTo("line2");
       assertThat(v2.message()).isEqualTo("size must be between 0 and 4");
 
       var v3 = violations.get(3);
-      assertThat(v3.path()).isEqualTo("address");
-      assertThat(v3.propertyName()).isEqualTo("longValue");
+      assertThat(v3.path()).isEqualTo("address.longValue");
+      assertThat(v3.field()).isEqualTo("longValue");
       assertThat(v3.message()).isEqualTo("must be greater than 0");
     }
   }

--- a/blackbox-test/src/test/java/example/avaje/nested/ANestedWithNullableTest.java
+++ b/blackbox-test/src/test/java/example/avaje/nested/ANestedWithNullableTest.java
@@ -24,8 +24,8 @@ class ANestedWithNullableTest {
       assertThat(violations).hasSize(1);
 
       var v0 = violations.get(0);
-      assertThat(v0.path()).isEqualTo("");
-      assertThat(v0.propertyName()).isEqualTo("lastName");
+      assertThat(v0.path()).isEqualTo("lastName");
+      assertThat(v0.field()).isEqualTo("lastName");
       assertThat(v0.message()).isEqualTo("size must be between 0 and 5");
     }
   }
@@ -42,8 +42,8 @@ class ANestedWithNullableTest {
       assertThat(violations).hasSize(1);
 
       var v0 = violations.get(0);
-      assertThat(v0.path()).isEqualTo("");
-      assertThat(v0.propertyName()).isEqualTo("lastName");
+      assertThat(v0.path()).isEqualTo("lastName");
+      assertThat(v0.field()).isEqualTo("lastName");
       assertThat(v0.message()).isEqualTo("size must be between 0 and 5");
     }
   }
@@ -60,23 +60,23 @@ class ANestedWithNullableTest {
       assertThat(violations).hasSize(4);
 
       var v0 = violations.get(0);
-      assertThat(v0.path()).isEqualTo("");
-      assertThat(v0.propertyName()).isEqualTo("lastName");
+      assertThat(v0.path()).isEqualTo("lastName");
+      assertThat(v0.field()).isEqualTo("lastName");
       assertThat(v0.message()).isEqualTo("size must be between 0 and 5");
 
       var v1 = violations.get(1);
-      assertThat(v1.path()).isEqualTo("address");
-      assertThat(v1.propertyName()).isEqualTo("line1");
+      assertThat(v1.path()).isEqualTo("address.line1");
+      assertThat(v1.field()).isEqualTo("line1");
       assertThat(v1.message()).isEqualTo("must not be blank");
 
       var v2 = violations.get(2);
-      assertThat(v2.path()).isEqualTo("address");
-      assertThat(v2.propertyName()).isEqualTo("line2");
+      assertThat(v2.path()).isEqualTo("address.line2");
+      assertThat(v2.field()).isEqualTo("line2");
       assertThat(v2.message()).isEqualTo("size must be between 0 and 4");
 
       var v3 = violations.get(3);
-      assertThat(v3.path()).isEqualTo("address");
-      assertThat(v3.propertyName()).isEqualTo("longValue");
+      assertThat(v3.path()).isEqualTo("address.longValue");
+      assertThat(v3.field()).isEqualTo("longValue");
       assertThat(v3.message()).isEqualTo("must be greater than 0");
     }
   }

--- a/blackbox-test/src/test/java/example/hibernate/HContact.java
+++ b/blackbox-test/src/test/java/example/hibernate/HContact.java
@@ -1,0 +1,29 @@
+package example.hibernate;
+
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Positive;
+
+@Valid
+public class HContact {
+
+  @NotEmpty
+  final String name;
+  @Positive
+  final long score;
+
+  public HContact(String name, long score) {
+    this.name = name;
+    this.score = score;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public long score() {
+    return score;
+  }
+
+}

--- a/blackbox-test/src/test/java/example/hibernate/HCustomer.java
+++ b/blackbox-test/src/test/java/example/hibernate/HCustomer.java
@@ -4,6 +4,9 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Valid
 public class HCustomer {
 
@@ -12,6 +15,9 @@ public class HCustomer {
 
     @NotBlank @Size(max = 7, message = "My custom error message with max {max}")
     final String other;
+
+    @Valid
+    final List<HContact> contacts = new ArrayList<>();
 
     public HCustomer(String name, String other) {
         this.name = name;
@@ -29,4 +35,8 @@ public class HCustomer {
     public String getOther() {
         return other;
     }
+
+  public List<HContact> contacts() {
+    return contacts;
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.avaje</groupId>
   <artifactId>avaje-validator-parent</artifactId>
-  <version>0.15</version>
+  <version>0.16</version>
 
   <packaging>pom</packaging>
   <name>validator parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <java.version>17</java.version>
     <java.release>17</java.release>
     <inject.version>9.4-RC3</inject.version>
-    <http.version>1.45</http.version>
+    <http.version>2.0-RC2</http.version>
   </properties>
 
   <modules>

--- a/validator-constraints/pom.xml
+++ b/validator-constraints/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.avaje</groupId>
 		<artifactId>avaje-validator-parent</artifactId>
-		<version>0.15</version>
+		<version>0.16</version>
 	</parent>
 	<artifactId>validator-constraints</artifactId>
 </project>

--- a/validator-generator/pom.xml
+++ b/validator-generator/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-api</artifactId>
-      <version>1.45</version>
+      <version>2.0-RC2</version>
       <optional>true</optional>
       <scope>provided</scope>
     </dependency>

--- a/validator-generator/pom.xml
+++ b/validator-generator/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-validator-parent</artifactId>
-    <version>0.15</version>
+    <version>0.16</version>
   </parent>
 
   <artifactId>avaje-validator-generator</artifactId>

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ClassReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ClassReader.java
@@ -122,14 +122,14 @@ final class ClassReader implements BeanReader {
   public void writeValidatorMethod(Append writer) {
     writer.eol();
     writer.append("  @Override").eol();
-    writer.append("  public boolean validate(%s value, ValidationRequest request, String propertyName) {", shortName).eol();
-    writer.append("    if (propertyName != null) {").eol();
-    writer.append("      request.pushPath(propertyName);").eol();
+    writer.append("  public boolean validate(%s value, ValidationRequest request, String field) {", shortName).eol();
+    writer.append("    if (field != null) {").eol();
+    writer.append("      request.pushPath(field);").eol();
     writer.append("    }").eol();
     for (final FieldReader allField : allFields) {
       allField.writeValidate(writer);
     }
-    writer.append("    if (propertyName != null) {").eol();
+    writer.append("    if (field != null) {").eol();
     writer.append("      request.popPath();").eol();
     writer.append("    }").eol();
     writer.append("    return true;", shortName).eol();

--- a/validator-generator/src/main/java/module-info.java
+++ b/validator-generator/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 module io.avaje.validation.generator {
 
   requires java.compiler;
-  requires io.avaje.validation.plugin;
+  requires static io.avaje.validation.plugin;
   requires static io.avaje.prism;
   requires static io.avaje.http.api;
   requires static io.avaje.validation.contraints;

--- a/validator-http-plugin/pom.xml
+++ b/validator-http-plugin/pom.xml
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-validator</artifactId>
-      <version>0.13</version>
+      <version>0.16.1</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>

--- a/validator-http-plugin/pom.xml
+++ b/validator-http-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-validator-parent</artifactId>
-    <version>0.15</version>
+    <version>0.16</version>
   </parent>
   <artifactId>avaje-validator-http-plugin</artifactId>
   <name>validator-http-plugin</name>
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-api</artifactId>
-      <version>1.45</version>
+      <version>2.0-RC2</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>

--- a/validator-http-plugin/src/main/java/io/avaje/validation/http/BeanValidator.java
+++ b/validator-http-plugin/src/main/java/io/avaje/validation/http/BeanValidator.java
@@ -37,7 +37,7 @@ public class BeanValidator implements io.avaje.http.api.Validator {
     List<Violation> errors = new ArrayList<>();
     for (final var violation : cause.violations()) {
       final var path = violation.path();
-      final var field = violation.propertyName();
+      final var field = violation.field();
       final var message = violation.message();
       errors.add(new Violation(path, field, message));
     }

--- a/validator-http-plugin/src/main/java/io/avaje/validation/http/BeanValidator.java
+++ b/validator-http-plugin/src/main/java/io/avaje/validation/http/BeanValidator.java
@@ -1,15 +1,11 @@
 package io.avaje.validation.http;
 
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import io.avaje.http.api.ValidationException;
+import io.avaje.http.api.ValidationException.Violation;
 import io.avaje.inject.BeanScope;
 import io.avaje.inject.PostConstruct;
-import io.avaje.validation.ConstraintViolation;
 import io.avaje.validation.ConstraintViolationException;
 import io.avaje.validation.Validator;
 
@@ -23,14 +19,12 @@ public class BeanValidator implements io.avaje.http.api.Validator {
   }
 
   @Override
-  public void validate(Object bean, String acceptLanguage, Class<?>... groups)
-      throws ValidationException {
-
+  public void validate(Object bean, String acceptLanguage, Class<?>... groups) throws ValidationException {
     final Locale language = resolveLocale(acceptLanguage, locales);
     try {
       validator.validate(bean, language, groups);
     } catch (final ConstraintViolationException e) {
-      throwExceptionWith(e.violations());
+      throwExceptionWith(e);
     }
   }
 
@@ -39,15 +33,15 @@ public class BeanValidator implements io.avaje.http.api.Validator {
     this.validator = scope.get(Validator.class);
   }
 
-  private void throwExceptionWith(Set<ConstraintViolation> violations) {
-
-    final Map<String, Object> errors = new LinkedHashMap<>();
-    for (final var violation : violations) {
+  private void throwExceptionWith(ConstraintViolationException cause) {
+    List<Violation> errors = new ArrayList<>();
+    for (final var violation : cause.violations()) {
       final var path = violation.path();
+      final var field = violation.propertyName();
       final var message = violation.message();
-      errors.put(path, message);
+      errors.add(new Violation(path, field, message));
     }
 
-    throw new ValidationException(422, "Request failed validation", errors);
+    throw new ValidationException(422, "Request failed validation", cause, errors);
   }
 }

--- a/validator-inject-plugin/pom.xml
+++ b/validator-inject-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-validator-parent</artifactId>
-    <version>0.15</version>
+    <version>0.16</version>
   </parent>
   <artifactId>avaje-validator-inject-plugin</artifactId>
   <name>validator-inject-plugin</name>

--- a/validator-inject-plugin/src/main/java/io/avaje/validation/inject/spi/DefaultValidatorProvider.java
+++ b/validator-inject-plugin/src/main/java/io/avaje/validation/inject/spi/DefaultValidatorProvider.java
@@ -64,13 +64,13 @@ public final class DefaultValidatorProvider implements io.avaje.inject.spi.Plugi
               .get("validation.temporal.tolerance.value")
               .map(Long::valueOf)
               .ifPresent(
-                  l -> {
+                  duration -> {
                     final var unit =
                         props
                             .get("validation.temporal.tolerance.chronoUnit")
                             .map(ChronoUnit::valueOf)
                             .orElse(ChronoUnit.MILLIS);
-                    validator.temporalTolerance(Duration.of(l, unit));
+                    validator.temporalTolerance(Duration.of(duration, unit));
                   });
           return validator.build();
         });

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-validator-parent</artifactId>
-    <version>0.15</version>
+    <version>0.16</version>
   </parent>
 
   <artifactId>avaje-validator</artifactId>

--- a/validator/src/main/java/io/avaje/validation/ConstraintViolation.java
+++ b/validator/src/main/java/io/avaje/validation/ConstraintViolation.java
@@ -4,38 +4,6 @@ package io.avaje.validation;
  * Describes a constraint violation. This object exposes the constraint violation context as well as
  * the message describing the violation.
  */
-public class ConstraintViolation {
+public record ConstraintViolation(String path, String propertyName, String message) {
 
-  private final String path;
-  private final String propertyName;
-  private final String message;
-
-  /**
-   * Create the ConstraintViolation with the given path, property and message.
-   */
-  public ConstraintViolation(String path, String propertyName, String message) {
-    this.path = path;
-    this.propertyName = propertyName;
-    this.message = message;
-  }
-
-  /** Return the path for this constraint violation */
-  public String path() {
-    return path;
-  }
-
-  /** Return the property name for this constraint violation */
-  public String propertyName() {
-    return propertyName;
-  }
-
-  /** Return the interpolated error message for this constraint violation */
-  public String message() {
-    return message;
-  }
-
-  @Override
-  public String toString() {
-    return message;
-  }
 }

--- a/validator/src/main/java/io/avaje/validation/ConstraintViolation.java
+++ b/validator/src/main/java/io/avaje/validation/ConstraintViolation.java
@@ -4,6 +4,6 @@ package io.avaje.validation;
  * Describes a constraint violation. This object exposes the constraint violation context as well as
  * the message describing the violation.
  */
-public record ConstraintViolation(String path, String propertyName, String message) {
+public record ConstraintViolation(String path, String field, String message) {
 
 }

--- a/validator/src/main/java/io/avaje/validation/adapter/AbstractContainerAdapter.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/AbstractContainerAdapter.java
@@ -29,18 +29,16 @@ public abstract class AbstractContainerAdapter<T> implements ValidationAdapter<T
   }
 
   /** Execute validations for all items in the given iterable */
-  protected boolean validateAll(
-      Iterable<Object> value, ValidationRequest req, String propertyName) {
+  protected boolean validateAll(Iterable<Object> value, ValidationRequest req, String propertyName) {
     if (value == null) {
       return true;
     }
     if (propertyName != null) {
       req.pushPath(propertyName);
     }
-    int index = -1;
+    int index = 0;
     for (final var element : value) {
-      index++;
-      multiAdapter.validate(element, req, String.valueOf(index));
+      multiAdapter.validate(element, req, "[" + index++);
     }
     if (propertyName != null) {
       req.popPath();

--- a/validator/src/main/java/io/avaje/validation/core/DRequest.java
+++ b/validator/src/main/java/io/avaje/validation/core/DRequest.java
@@ -30,18 +30,29 @@ final class DRequest implements ValidationRequest {
   }
 
   private String currentPath() {
-    final StringJoiner joiner = new StringJoiner(".");
+    if (pathStack.isEmpty()) {
+      return "";
+    }
+    final StringBuilder sb = new StringBuilder(70);
     final var descendingIterator = pathStack.descendingIterator();
     while (descendingIterator.hasNext()) {
-      joiner.add(descendingIterator.next());
+      String next = descendingIterator.next();
+      if (next.charAt(0) == '[') {
+        sb.append(next).append(']');
+      } else {
+        if (!sb.isEmpty()) {
+          sb.append('.');
+        }
+        sb.append(next);
+      }
     }
-    return joiner.toString();
+    return sb.append('.').toString();
   }
 
   @Override
   public void addViolation(ValidationContext.Message msg, String propertyName) {
     final String message = validator.interpolate(msg, locale);
-    violations.add(new ConstraintViolation(currentPath(), propertyName, message));
+    violations.add(new ConstraintViolation(currentPath() + propertyName, propertyName, message));
     if (failfast) {
       throwWithViolations();
     }

--- a/validator/src/test/java/io/avaje/validation/core/ValidatorTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/ValidatorTest.java
@@ -71,8 +71,8 @@ class ValidatorTest {
       List<ConstraintViolation> asList = new ArrayList<>(violations);
 
       var last = asList.get(violations.size() - 1);
-      assertThat(last.path()).isEqualTo("contacts.1.address");
-      assertThat(last.propertyName()).isEqualTo("line1");
+      assertThat(last.path()).isEqualTo("contacts[1].address.line1");
+      assertThat(last.field()).isEqualTo("line1");
       assertThat(last.message()).isEqualTo("myCustomNullMessage");
     }
   }
@@ -89,8 +89,8 @@ class ValidatorTest {
       List<ConstraintViolation> asList = new ArrayList<>(violations);
 
       var first = asList.get(0);
-      assertThat(first.path()).isEqualTo("");
-      assertThat(first.propertyName()).isEqualTo("lastName");
+      assertThat(first.path()).isEqualTo("lastName");
+      assertThat(first.field()).isEqualTo("lastName");
       assertThat(first.message()).isEqualTo("must not be null");
     }
   }
@@ -109,8 +109,8 @@ class ValidatorTest {
       List<ConstraintViolation> asList = new ArrayList<>(violations);
 
       var first = asList.get(0);
-      assertThat(first.path()).isEqualTo("");
-      assertThat(first.propertyName()).isEqualTo("billingAddress");
+      assertThat(first.path()).isEqualTo("billingAddress");
+      assertThat(first.field()).isEqualTo("billingAddress");
       assertThat(first.message()).isEqualTo("must not be null");
     }
   }


### PR DESCRIPTION
Also:

  - module-info, make io.avaje.validation.plugin static (optional)
  - Change ConstraintViolation into a record type
  - Using avaje-http-api 2.0-RC2
  - Hibernate test showing path in the form contacts[0].name for nested collections
  - Rename ConstraintViolation propertyName -> field + fix path to be consistent with hibernate validator