### PR TITLE
Add optional max length attribute to @NotBlank

### DIFF
--- a/blackbox-test/src/test/java/example/avaje/notblank/ANotBlank.java
+++ b/blackbox-test/src/test/java/example/avaje/notblank/ANotBlank.java
@@ -1,0 +1,16 @@
+package example.avaje.notblank;
+
+import io.avaje.validation.constraints.NotBlank;
+import jakarta.validation.Valid;
+
+@Valid
+public record ANotBlank(
+  @NotBlank
+  String basic,
+  @NotBlank(max = 4)
+  String withMax,
+
+  @NotBlank(max = 4, message = "NotBlank n max 4")
+  String withCustom
+) {
+}

--- a/blackbox-test/src/test/java/example/avaje/notblank/ANotBlankTest.java
+++ b/blackbox-test/src/test/java/example/avaje/notblank/ANotBlankTest.java
@@ -1,0 +1,89 @@
+package example.avaje.notblank;
+
+import io.avaje.validation.ConstraintViolation;
+import io.avaje.validation.ConstraintViolationException;
+import io.avaje.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+class ANotBlankTest {
+
+  final Validator validator = Validator.builder().addLocales(Locale.GERMAN).build();
+
+  @Test
+  void valid() {
+    var value = new ANotBlank("ok", "ok", "ok");
+    validator.validate(value);
+  }
+
+  @Test
+  void inValidNull() {
+    var value = new ANotBlank(null, null, null);
+    try {
+      validator.validate(value);
+      fail("not get here");
+    } catch (ConstraintViolationException e) {
+      assertThat(e.violations()).hasSize(3);
+    }
+  }
+
+  @Test
+  void invalidBlank() {
+    var violation = one(new ANotBlank("", "ok", "ok"));
+    assertThat(violation.message()).isEqualTo("must not be blank");
+
+    var violation1 = one(new ANotBlank("ok", " ", "ok"));
+    assertThat(violation1.message()).isEqualTo("must not be blank");
+
+    var violation2 = one(new ANotBlank("ok", "ok", "\t"));
+    assertThat(violation2.message()).isEqualTo("NotBlank n max 4");
+  }
+
+  @Test
+  void invalidMax() {
+    var violation = one(new ANotBlank("ok", "NotValid", "ok"));
+    assertThat(violation.message()).isEqualTo("maximum length 4 exceeded");
+
+    var violation1 = one(new ANotBlank("ok", "ok", "NotValid"));
+    assertThat(violation1.message()).isEqualTo("NotBlank n max 4");
+  }
+
+  @Test
+  void invalidAsDE() {
+    var violation = one(new ANotBlank(" ", "ok", "ok"), Locale.GERMAN);
+    assertThat(violation.message()).isEqualTo("darf nicht leer sein");
+  }
+
+  @Test
+  void invalidWithMaxDE() {
+    var violation = one(new ANotBlank("ok", "NotValid", "ok"), Locale.GERMAN);
+    assertThat(violation.message()).isEqualTo("Länge muss zwischen 1 und 4 sein");
+  }
+
+  @Test
+  void invalidCustomMessageDE() {
+    var violation = one(new ANotBlank("ok", "ok", "NotValid"), Locale.GERMAN);
+    assertThat(violation.message()).isEqualTo("NotBlank n max 4");
+  }
+
+  ConstraintViolation one(Object any) {
+    return one(any, Locale.ENGLISH);
+  }
+
+  ConstraintViolation one(Object any, Locale locale) {
+    try {
+      validator.validate(any, locale);
+      fail("not expected");
+      return null;
+    } catch (ConstraintViolationException e) {
+      var violations = new ArrayList<>(e.violations());
+      assertThat(violations).hasSize(1);
+      return violations.get(0);
+    }
+  }
+}

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/NotBlank.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/NotBlank.java
@@ -28,6 +28,9 @@ import io.avaje.validation.constraints.NotBlank.List;
 @Repeatable(List.class)
 public @interface NotBlank {
 
+  /** Set the maximum length. By default this is 0 meaning unlimited. */
+  int max() default 0;
+
   String message() default "{avaje.NotBlank.message}";
 
   Class<?>[] groups() default {};

--- a/validator/src/main/java/io/avaje/validation/adapter/ValidationContext.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/ValidationContext.java
@@ -164,7 +164,7 @@ public interface ValidationContext {
 
     Message message();
 
-    Message message(String key);
+    Message message(String key, Object... extraKeyValues);
 
     String targetType();
 

--- a/validator/src/main/java/io/avaje/validation/core/CoreAdapterBuilder.java
+++ b/validator/src/main/java/io/avaje/validation/core/CoreAdapterBuilder.java
@@ -134,9 +134,14 @@ final class CoreAdapterBuilder {
     }
 
     @Override
-    public ValidationContext.Message message(String messageKey) {
+    public ValidationContext.Message message(String messageKey, Object... extraKeyValues) {
       Map<String, Object> newAttributes = new HashMap<>(attributes);
       newAttributes.put("message", messageKey);
+      if (extraKeyValues != null) {
+        for (int i = 0; i < extraKeyValues.length; i += 2) {
+          newAttributes.put(String.valueOf(extraKeyValues[i]), extraKeyValues[i + 1]);
+        }
+      }
       return ctx.message(newAttributes);
     }
   }

--- a/validator/src/main/resources/io/avaje/validation/Messages_en.properties
+++ b/validator/src/main/resources/io/avaje/validation/Messages_en.properties
@@ -1,3 +1,2 @@
-## Intentionally blank
 avaje.Length.max.message      = maximum length {max} exceeded
 avaje.Size.max.message        = maximum size {max} exceeded


### PR DESCRIPTION
By default this will produce 2 different error messages, one for "not blank" and another for "max length".

An alternative of a {avaje.NotBlank.max.message} was tried which combined the 2 messages into a single error message but this felt less satisfactory than the 2 messages which are more clear as to the reason of the violation error.