### PR TITLE
Repair Custom Adapters/Class Constraints

### DIFF
--- a/validator-generator/src/main/java/io/avaje/validation/generator/ContraintReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ContraintReader.java
@@ -27,8 +27,8 @@ final class ContraintReader implements BeanReader {
     importTypes.add("java.util.Map");
     importTypes.add("io.avaje.validation.adapter.ConstraintAdapter");
     importTypes.add("io.avaje.validation.adapter.ValidationAdapter");
-    importTypes.add("io.avaje.validation.adapter.ValidationContext");
     importTypes.add("io.avaje.validation.adapter.ValidationRequest");
+    importTypes.add("io.avaje.validation.adapter.ValidationContext.AdapterCreateRequest");
     importTypes.add("io.avaje.validation.spi.Generated");
 
     this.annotations =
@@ -121,7 +121,9 @@ final class ContraintReader implements BeanReader {
 
     writer.append(
         """
-    final var message = ctx.<Object>message(attributes).template();
+    final var message = req.message().template();
+    final var ctx = req.ctx();
+    final var groups = req.groups();
     this.adapter =
 """);
 

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
@@ -8,7 +8,6 @@ import java.util.Set;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 
 // TODO: better name???
@@ -20,7 +19,7 @@ public record ElementAnnotationContainer(
     Map<GenericType, String> typeUse2) {
 
   static ElementAnnotationContainer create(Element element) {
-    final var hasValid = !(element instanceof TypeElement) && ValidPrism.isPresent(element);
+    final var hasValid = ValidPrism.isPresent(element);
     String rawType;
     Map<GenericType, String> typeUse1;
     Map<GenericType, String> typeUse2;
@@ -50,7 +49,7 @@ public record ElementAnnotationContainer(
 
     final var annotations =
         element.getAnnotationMirrors().stream()
-            .filter(m -> !hasValid && !ValidPrism.isInstance(m))
+            .filter(m -> !ValidPrism.isInstance(m))
             .collect(
                 toMap(
                     a -> GenericType.parse(a.getAnnotationType().toString()),

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 
 // TODO: better name???
@@ -19,7 +20,7 @@ public record ElementAnnotationContainer(
     Map<GenericType, String> typeUse2) {
 
   static ElementAnnotationContainer create(Element element) {
-    final var hasValid = ValidPrism.isPresent(element);
+    final var hasValid = !(element instanceof TypeElement) && ValidPrism.isPresent(element);
     String rawType;
     Map<GenericType, String> typeUse1;
     Map<GenericType, String> typeUse2;

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
@@ -50,6 +50,7 @@ public record ElementAnnotationContainer(
 
     final var annotations =
         element.getAnnotationMirrors().stream()
+            .filter(m -> !hasValid && !ValidPrism.isInstance(m))
             .collect(
                 toMap(
                     a -> GenericType.parse(a.getAnnotationType().toString()),
@@ -94,5 +95,9 @@ public record ElementAnnotationContainer(
     annotations.keySet().forEach(t -> t.addImports(importTypes));
     typeUse1.keySet().forEach(t -> t.addImports(importTypes));
     typeUse2.keySet().forEach(t -> t.addImports(importTypes));
+  }
+
+  boolean isEmpty() {
+    return annotations.isEmpty() && typeUse1.isEmpty() && typeUse2.isEmpty();
   }
 }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/FieldReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/FieldReader.java
@@ -175,4 +175,8 @@ final class FieldReader {
   public boolean isClassLvl() {
     return classLevel;
   }
+
+  public boolean hasAnnotations() {
+    return !elementAnnotations.isEmpty();
+  }
 }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/SimpleAdapterWriter.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/SimpleAdapterWriter.java
@@ -50,15 +50,15 @@ final class SimpleAdapterWriter {
   }
 
   private void writeConstructor() {
-    writer.append("  public %sValidationAdapter(ValidationContext ctx", adapterShortName);
-    for (int i = 0; i < genericParamsCount; i++) {
-      writer.append(", Type param%d", i);
-    }
 
-    if (beanReader instanceof ContraintReader) {
-      writer.append(", Set<Class<?>> groups, Map<String, Object> attributes");
+    if (isContraint) {
+      writer.append("  public %sValidationAdapter(AdapterCreateRequest req", adapterShortName);
+    } else {
+      writer.append("  public %sValidationAdapter(ValidationContext ctx", adapterShortName);
+      for (int i = 0; i < genericParamsCount; i++) {
+        writer.append(", Type param%d", i);
+      }
     }
-
     writer.append(") {", adapterShortName).eol();
     beanReader.writeConstructor(writer);
     writer.append("  }").eol();

--- a/validator-generator/src/main/java/io/avaje/validation/generator/TypeReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/TypeReader.java
@@ -32,14 +32,14 @@ final class TypeReader {
   private final Map<String, MethodReader> allGetterMethods = new LinkedHashMap<>();
   private final Map<String, MethodReader> maybeGetterMethods = new LinkedHashMap<>();
   private final TypeElement baseType;
-  private final boolean hasJsonAnnotation;
+  private final boolean hasValidAnnotation;
   private final Set<String> seenFields = new HashSet<>();
   private boolean nonAccessibleField;
   private final List<String> genericTypeParams;
 
   TypeReader(TypeElement baseType) {
     this.baseType = baseType;
-    this.hasJsonAnnotation = Util.isValid(baseType);
+    this.hasValidAnnotation = Util.isValid(baseType);
     this.genericTypeParams = initTypeParams(baseType);
   }
 
@@ -57,6 +57,8 @@ final class TypeReader {
           break;
       }
     }
+
+    localFields.add(new FieldReader(type, genericTypeParams));
 
     for (final FieldReader localField : localFields) {
       allFields.add(localField);
@@ -93,10 +95,8 @@ final class TypeReader {
       final List<? extends VariableElement> parameters = methodElement.getParameters();
       final String methodKey = methodElement.getSimpleName().toString();
       final MethodReader methodReader = new MethodReader(methodElement, type).read();
-      if (parameters.size() == 0) {
-        if (!maybeGetterMethods.containsKey(methodKey)) {
-          maybeGetterMethods.put(methodKey, methodReader);
-        }
+      if (parameters.isEmpty()) {
+        maybeGetterMethods.putIfAbsent(methodKey, methodReader);
         allGetterMethods.put(methodKey.toLowerCase(), methodReader);
       }
       // for reading methods
@@ -112,6 +112,9 @@ final class TypeReader {
 
   private void matchFieldsToGetter() {
     for (final FieldReader field : allFields) {
+      if (field.isClassLvl()) {
+        continue;
+      }
       matchFieldToGetter(field);
     }
   }
@@ -121,8 +124,13 @@ final class TypeReader {
         && !matchFieldToGetter2(field, true)
         && !field.isPublicField()) {
       nonAccessibleField = true;
-      if (hasJsonAnnotation) {
-        logError("Non accessible field " + baseType + " " + field.fieldName() + " with no matching getter?");
+      if (hasValidAnnotation) {
+        logError(
+            "Non accessible field "
+                + baseType
+                + " "
+                + field.fieldName()
+                + " with no matching getter?");
       } else {
         logDebug("Non accessible field " + baseType + " " + field.fieldName());
       }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/TypeReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/TypeReader.java
@@ -58,7 +58,7 @@ final class TypeReader {
       }
     }
 
-    final var classAdapter = new FieldReader(type, genericTypeParams);
+    final var classAdapter = new FieldReader(type, genericTypeParams, true);
     if (classAdapter.hasAnnotations()) {
       localFields.add(classAdapter);
     }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/TypeReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/TypeReader.java
@@ -58,7 +58,10 @@ final class TypeReader {
       }
     }
 
-    localFields.add(new FieldReader(type, genericTypeParams));
+    final var classAdapter = new FieldReader(type, genericTypeParams);
+    if (classAdapter.hasAnnotations()) {
+      localFields.add(classAdapter);
+    }
 
     for (final FieldReader localField : localFields) {
       allFields.add(localField);

--- a/validator-generator/src/main/java/io/avaje/validation/generator/Util.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/Util.java
@@ -260,7 +260,9 @@ final class Util {
   /** Return the base type given the ValidationAdapter type. */
   static String baseTypeOfAdapter(String adapterFullName) {
     final var element = element(adapterFullName);
-
+    if (element == null) {
+      throw new NullPointerException("Element not found for [" + adapterFullName + "]");
+    }
     return Optional.of(element.getSuperclass())
         .filter(t -> t.toString().contains("io.avaje.validation.adapter.AbstractConstraintAdapter"))
         .or(validationAdapter(element))

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ValidPrism.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ValidPrism.java
@@ -1,5 +1,6 @@
 package io.avaje.validation.generator;
 
+import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 
 public interface ValidPrism {
@@ -9,5 +10,12 @@ public interface ValidPrism {
         || JakartaValidPrism.isPresent(e)
         || JavaxValidPrism.isPresent(e)
         || HttpValidPrism.isPresent(e);
+  }
+
+  static boolean isInstance(AnnotationMirror e) {
+    return AvajeValidPrism.getInstance(e) != null
+        || JakartaValidPrism.getInstance(e) != null
+        || JavaxValidPrism.getInstance(e) != null
+        || HttpValidPrism.getInstance(e) != null;
   }
 }

--- a/validator-generator/src/test/java/io/avaje/validation/generator/ValidatorProcessorTest.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/ValidatorProcessorTest.java
@@ -44,7 +44,6 @@ class ValidatorProcessorTest {
     }
   }
 
-  @Disabled
   @Test
   void testGeneration() throws Exception {
     final String source =

--- a/validator-generator/src/test/java/io/avaje/validation/generator/ValidatorProcessorTest.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/ValidatorProcessorTest.java
@@ -22,7 +22,6 @@ import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class ValidatorProcessorTest {

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/CheckCaseAdapter.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/CheckCaseAdapter.java
@@ -2,15 +2,15 @@ package io.avaje.validation.generator.models.valid;
 
 import io.avaje.validation.adapter.AbstractConstraintAdapter;
 import io.avaje.validation.adapter.ConstraintAdapter;
-import io.avaje.validation.adapter.ValidationContext;
+import io.avaje.validation.adapter.ValidationContext.AdapterCreateRequest;
 import io.avaje.validation.generator.models.valid.CheckCase.CaseMode;
 
 @ConstraintAdapter(CheckCase.class)
-public final class CustomAnnotationAdapter extends AbstractConstraintAdapter<String> {
+public final class CheckCaseAdapter extends AbstractConstraintAdapter<String> {
 
   private final CaseMode caseMode;
 
-  public CustomAnnotationAdapter(ValidationContext.AdapterCreateRequest request) {
+  public CheckCaseAdapter(AdapterCreateRequest request) {
     super(request);
     final var attributes = request.attributes();
     caseMode = (CaseMode) attributes.get("caseMode");

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/typeconstraint/PassingSkill.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/typeconstraint/PassingSkill.java
@@ -1,0 +1,18 @@
+package io.avaje.validation.generator.models.valid.typeconstraint;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import io.avaje.validation.constraints.Constraint;
+
+@Target(TYPE)
+@Retention(SOURCE)
+@Constraint
+public @interface PassingSkill {
+  String message() default "put these foolish ambitions to rest"; // default error message
+
+  Class<?>[] groups() default {}; // groups
+}

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/typeconstraint/PassingSkillAdapter.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/typeconstraint/PassingSkillAdapter.java
@@ -1,0 +1,21 @@
+package io.avaje.validation.generator.models.valid.typeconstraint;
+
+import io.avaje.validation.adapter.AbstractConstraintAdapter;
+import io.avaje.validation.adapter.ConstraintAdapter;
+import io.avaje.validation.adapter.ValidationContext.AdapterCreateRequest;
+
+@ConstraintAdapter(PassingSkill.class)
+public final class PassingSkillAdapter extends AbstractConstraintAdapter<Tarnished> {
+
+  public PassingSkillAdapter(AdapterCreateRequest request) {
+    super(request);
+  }
+
+  @Override
+  public boolean isValid(Tarnished lowlyTarnished) {
+    if (lowlyTarnished == null) {
+      return true;
+    }
+    return lowlyTarnished.vigor() >= 50 && lowlyTarnished.endurance() >= 50;
+  }
+}

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/typeconstraint/Tarnished.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/typeconstraint/Tarnished.java
@@ -1,0 +1,7 @@
+package io.avaje.validation.generator.models.valid.typeconstraint;
+
+import io.avaje.validation.constraints.Valid;
+
+@Valid
+@PassingSkill
+public record Tarnished(int vigor, int endurance) {}

--- a/validator/src/main/java/io/avaje/validation/Validator.java
+++ b/validator/src/main/java/io/avaje/validation/Validator.java
@@ -1,20 +1,20 @@
 package io.avaje.validation;
 
-import io.avaje.lang.Nullable;
-import io.avaje.validation.adapter.*;
-import io.avaje.validation.core.DefaultBootstrap;
-import io.avaje.validation.spi.MessageInterpolator;
-import io.avaje.validation.spi.ValidatorCustomizer;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Locale;
-import java.util.Map;
 import java.util.ResourceBundle;
-import java.util.Set;
 import java.util.function.Supplier;
+
+import io.avaje.lang.Nullable;
+import io.avaje.validation.adapter.ValidationAdapter;
+import io.avaje.validation.adapter.ValidationContext;
+import io.avaje.validation.adapter.ValidationContext.AdapterCreateRequest;
+import io.avaje.validation.core.DefaultBootstrap;
+import io.avaje.validation.spi.MessageInterpolator;
+import io.avaje.validation.spi.ValidatorCustomizer;
 
 /**
  * Validate plain Java objects that have been annotated with validation constraints.
@@ -145,8 +145,7 @@ public interface Validator {
   interface AnnotationAdapterBuilder {
 
     /** Create a ValidationAdapter given the Validator instance. */
-    ValidationAdapter<?> build(
-        ValidationContext ctx, Set<Class<?>> groups, Map<String, Object> attributes);
+    ValidationAdapter<?> build(AdapterCreateRequest request);
   }
 
   /** Components register ValidationAdapters Validator.Builder */

--- a/validator/src/main/java/io/avaje/validation/adapter/AbstractContainerAdapter.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/AbstractContainerAdapter.java
@@ -6,9 +6,7 @@ package io.avaje.validation.adapter;
  */
 public abstract class AbstractContainerAdapter<T> implements ValidationAdapter<T> {
 
-	/**
-	 * Adapter placed on the container type
-	 */
+  /** Adapter placed on the container type */
   protected final ValidationAdapter<T> initalAdapter;
 
   protected ValidationAdapter<Object> multiAdapter;

--- a/validator/src/main/java/io/avaje/validation/adapter/ConstraintAdapter.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/ConstraintAdapter.java
@@ -19,12 +19,12 @@ import java.lang.annotation.Target;
  *
  *   String value;
  *
- *   public CustomAnnotationAdapter(ValidationContext ctx, Set<Class<?>> groups, Map<String, Object> attributes) {
+ *   public CustomAnnotationAdapter(AdapterCreateRequest req) {
  *     //create a message object for error interpolation and set groups
- *      super(ctx.message(attributes), groups);
+ *      super(req);
  *
  *      //use the attributes to extract the annotation values
- *      value = (String) attributes.get("value");
+ *      value = (String) req.attribute("value");
  *   }
  *
  *

--- a/validator/src/main/java/io/avaje/validation/adapter/ValidationContext.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/ValidationContext.java
@@ -41,8 +41,8 @@ public interface ValidationContext {
   <T> ValidationAdapter<T> adapter(Class<? extends Annotation> cls, Map<String, Object> attributes);
 
   /**
-   * Return the constraint adapter for the given annotation with attributes. Used for adapters that combine
-   * multiple annotation adapters.
+   * Return the constraint adapter for the given annotation with attributes. Used for adapters that
+   * combine multiple annotation adapters.
    *
    * @param cls The class representing the annotation type
    * @param groups The validation groups associated with the annotation

--- a/validator/src/main/java/io/avaje/validation/adapter/ValidationRequest.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/ValidationRequest.java
@@ -26,4 +26,7 @@ public interface ValidationRequest {
 
   /** Throw ConstraintViolationException if there are violations in this request. */
   void throwWithViolations() throws ConstraintViolationException;
+
+  /** return true if there are violations in this request. */
+  boolean hasViolations();
 }

--- a/validator/src/main/java/io/avaje/validation/core/DRequest.java
+++ b/validator/src/main/java/io/avaje/validation/core/DRequest.java
@@ -36,7 +36,7 @@ final class DRequest implements ValidationRequest {
     final StringBuilder sb = new StringBuilder(70);
     final var descendingIterator = pathStack.descendingIterator();
     while (descendingIterator.hasNext()) {
-      String next = descendingIterator.next();
+      final String next = descendingIterator.next();
       if (next.charAt(0) == '[') {
         sb.append(next).append(']');
       } else {
@@ -78,5 +78,15 @@ final class DRequest implements ValidationRequest {
   @Override
   public List<Class<?>> groups() {
     return groups;
+  }
+
+  @Override
+  public String toString() {
+    return violations.toString();
+  }
+
+  @Override
+  public boolean hasViolations() {
+    return !violations.isEmpty();
   }
 }

--- a/validator/src/main/java/io/avaje/validation/core/DValidator.java
+++ b/validator/src/main/java/io/avaje/validation/core/DValidator.java
@@ -89,7 +89,8 @@ final class DValidator implements Validator, ValidationContext {
 
   @SuppressWarnings("unchecked")
   private <T> ValidationType<T> typeWithCache(Type type) {
-    return (ValidationType<T>) typeCache.computeIfAbsent(type, k -> new ValidationType<>(this, adapter(k)));
+    return (ValidationType<T>)
+        typeCache.computeIfAbsent(type, k -> new ValidationType<>(this, adapter(k)));
   }
 
   @Override
@@ -116,7 +117,8 @@ final class DValidator implements Validator, ValidationContext {
   }
 
   @Override
-  public <T> ValidationAdapter<T> adapter(Class<? extends Annotation> cls, Map<String, Object> attributes) {
+  public <T> ValidationAdapter<T> adapter(
+      Class<? extends Annotation> cls, Map<String, Object> attributes) {
     return builder.annotationAdapter(cls, attributes, null);
   }
 
@@ -302,8 +304,7 @@ final class DValidator implements Validator, ValidationContext {
         Type type, ValidationAdapter<T> adapter) {
       requireNonNull(type);
       requireNonNull(adapter);
-      return (request) ->
-          simpleMatch(type, request.annotationType()) ? adapter : null;
+      return (request) -> simpleMatch(type, request.annotationType()) ? adapter : null;
     }
 
     private static <T> AdapterFactory newAdapterFactory(Type type, ValidationAdapter<T> adapter) {
@@ -322,8 +323,7 @@ final class DValidator implements Validator, ValidationContext {
         Class<? extends Annotation> type, AnnotationAdapterBuilder builder) {
       requireNonNull(type);
       requireNonNull(builder);
-      return (req) ->
-          simpleMatch(type, req.annotationType()) ? builder.build(req.ctx(), req.groups(), req.attributes()) : null;
+      return (req) -> simpleMatch(type, req.annotationType()) ? builder.build(req) : null;
     }
 
     private static boolean simpleMatch(Type type, Type targetType) {


### PR DESCRIPTION
Fix broken adapter generation and introduces the concept of class constraints.

given a class:
```java
@Valid
@PassingSkill
public record Tarnished(int vigor, int endurance) {}
```
the generator will look through the class level annotations and add to the adapter:

```java
@Generated
public final class TarnishedValidationAdapter implements ValidationAdapter<Tarnished> {

  private final ValidationAdapter<Tarnished> tarnishedValidationAdapter;

  public TarnishedValidationAdapter(ValidationContext ctx) {
    this.tarnishedValidationAdapter = 
        ctx.<Tarnished>adapter(PassingSkill.class, Map.of("message","put these foolish ambitions to rest", "groups",Set.of()));
  }

  @Override
  public boolean validate(Tarnished value, ValidationRequest request, String field) {
    if (field != null) {
      request.pushPath(field);
    }

    tarnishedValidationAdapter.validate(value, request, field);

    if (field != null) {
      request.popPath();
    }

    return true;
  }
}
```

fixes #107 