### PR TITLE
Fix for class level validation (recursive adapter creation)

### DIFF
--- a/blackbox-test/src/main/java/example/avaje/crossfield/APassingSkill.java
+++ b/blackbox-test/src/main/java/example/avaje/crossfield/APassingSkill.java
@@ -1,0 +1,18 @@
+package example.avaje.crossfield;
+
+import io.avaje.validation.constraints.Constraint;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+@Target(TYPE)
+@Retention(SOURCE)
+@Constraint
+public @interface APassingSkill {
+  String message() default "put these foolish ambitions to rest"; // default error message
+
+  Class<?>[] groups() default {}; // groups
+}

--- a/blackbox-test/src/main/java/example/avaje/crossfield/APassingSkillAdapter.java
+++ b/blackbox-test/src/main/java/example/avaje/crossfield/APassingSkillAdapter.java
@@ -1,0 +1,21 @@
+package example.avaje.crossfield;
+
+import io.avaje.validation.adapter.AbstractConstraintAdapter;
+import io.avaje.validation.adapter.ConstraintAdapter;
+import io.avaje.validation.adapter.ValidationContext.AdapterCreateRequest;
+
+@ConstraintAdapter(APassingSkill.class)
+public final class APassingSkillAdapter extends AbstractConstraintAdapter<ATarnished> {
+
+  public APassingSkillAdapter(AdapterCreateRequest request) {
+    super(request);
+  }
+
+  @Override
+  public boolean isValid(ATarnished lowlyTarnished) {
+    if (lowlyTarnished == null) {
+      return true;
+    }
+    return lowlyTarnished.vigor() >= 50 && lowlyTarnished.endurance() >= 50;
+  }
+}

--- a/blackbox-test/src/main/java/example/avaje/crossfield/ATarnished.java
+++ b/blackbox-test/src/main/java/example/avaje/crossfield/ATarnished.java
@@ -1,0 +1,13 @@
+package example.avaje.crossfield;
+
+import io.avaje.validation.constraints.NotBlank;
+import io.avaje.validation.constraints.Positive;
+import io.avaje.validation.constraints.Valid;
+
+@Valid
+@APassingSkill
+public record ATarnished(
+  @NotBlank String name,
+  @Positive int vigor,
+  @Positive int endurance) {
+}

--- a/blackbox-test/src/test/java/example/avaje/crossfield/ATarnishedTest.java
+++ b/blackbox-test/src/test/java/example/avaje/crossfield/ATarnishedTest.java
@@ -1,0 +1,58 @@
+package example.avaje.crossfield;
+
+import io.avaje.validation.ConstraintViolation;
+import io.avaje.validation.ConstraintViolationException;
+import io.avaje.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+class ATarnishedTest {
+
+  Validator validator = Validator.builder().build();
+
+  @Test
+  void valid() {
+    validator.validate(new ATarnished("ok", 50, 50));
+  }
+
+  @Test
+  void invalid_classLevelValidation() {
+    var violation = one(new ATarnished("ok", 49, 50));
+    assertThat(violation.message()).isEqualTo("put these foolish ambitions to rest");
+    assertThat(violation.path()).isEqualTo("null");
+    assertThat(violation.field()).isNull();
+  }
+
+
+  @Test
+  void invalidField_expect_classValidationToNotRun() {
+    var violation = one(new ATarnished(" ", 49, 50));
+    assertThat(violation.message()).isEqualTo("must not be blank");
+    assertThat(violation.path()).isEqualTo("name");
+    assertThat(violation.field()).isEqualTo("name");
+  }
+
+  @Test
+  void invalidField2_expect_classValidationToNotRun() {
+    var violation = one(new ATarnished("ok", -1, 50));
+    assertThat(violation.message()).isEqualTo("must be greater than 0");
+    assertThat(violation.path()).isEqualTo("vigor");
+    assertThat(violation.field()).isEqualTo("vigor");
+  }
+
+  ConstraintViolation one(Object any) {
+    try {
+      validator.validate(any);
+      fail("not expected");
+      return null;
+    } catch (ConstraintViolationException e) {
+      var violations = new ArrayList<>(e.violations());
+      assertThat(violations).hasSize(1);
+      return violations.get(0);
+    }
+  }
+}

--- a/validator-generator/src/main/java/io/avaje/validation/generator/AdapterHelper.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/AdapterHelper.java
@@ -12,18 +12,20 @@ class AdapterHelper {
   private final String type;
   private final GenericType topType;
   private final GenericType genericType;
+  private final boolean classLevel;
 
   AdapterHelper(Append writer, ElementAnnotationContainer elementAnnotations, String indent) {
-    this(writer, elementAnnotations, indent,"Object", null);
+    this(writer, elementAnnotations, indent,"Object", null, false);
   }
 
-  AdapterHelper(Append writer, ElementAnnotationContainer elementAnnotations, String indent, String type, GenericType topType) {
+  AdapterHelper(Append writer, ElementAnnotationContainer elementAnnotations, String indent, String type, GenericType topType, boolean classLevel) {
     this.writer = writer;
     this.elementAnnotations = elementAnnotations;
     this.indent = indent;
     this.type = type;
     this.topType = topType;
     this.genericType = elementAnnotations.genericType();
+    this.classLevel = classLevel;
   }
 
   void write() {
@@ -70,7 +72,9 @@ class AdapterHelper {
       writeTypeUse(genericType.firstParamType(), typeUse1);
 
     } else if (hasValid) {
-      writer.eol().append("%s    .andThen(ctx.adapter(%s.class))", indent, Util.shortName(genericType.topType()));
+      if (!classLevel) {
+        writer.eol().append("%s    .andThen(ctx.adapter(%s.class))", indent, Util.shortName(genericType.topType()));
+      }
 
     } else if (genericType.topType().contains("java.util.Optional")) {
       writer.eol().append("%s    .optional()", indent);

--- a/validator-generator/src/main/java/io/avaje/validation/generator/FieldReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/FieldReader.java
@@ -182,7 +182,8 @@ final class FieldReader {
             elementAnnotations,
             "        ",
             PrimitiveUtil.wrap(genericType.shortType()),
-            genericType)
+            genericType,
+            classLevel)
         .write();
     writer.append(";").eol().eol();
   }


### PR DESCRIPTION
Specifically we don't want the .andThen(..) for the class level validation as then its recursive