### PR TITLE
Cross Parameter Validation

### DIFF
--- a/blackbox-test/pom.xml
+++ b/blackbox-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-validator-parent</artifactId>
-    <version>1.0-RC2</version>
+    <version>1.0-RC3</version>
   </parent>
 
   <artifactId>validator-blackbox-test</artifactId>
@@ -37,6 +37,12 @@
       <artifactId>avaje-validator</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-validator-http-plugin</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>validator-constraints</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.avaje</groupId>
   <artifactId>avaje-validator-parent</artifactId>
-  <version>1.0-RC2</version>
+  <version>1.0-RC3</version>
 
   <packaging>pom</packaging>
   <name>validator parent</name>

--- a/validator-constraints/pom.xml
+++ b/validator-constraints/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.avaje</groupId>
 		<artifactId>avaje-validator-parent</artifactId>
-		<version>1.0-RC2</version>
+		<version>1.0-RC3</version>
 	</parent>
 	<artifactId>validator-constraints</artifactId>
 </project>

--- a/validator-generator/pom.xml
+++ b/validator-generator/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-validator-parent</artifactId>
-    <version>1.0-RC2</version>
+    <version>1.0-RC3</version>
   </parent>
 
   <artifactId>avaje-validator-generator</artifactId>

--- a/validator-generator/src/main/java/io/avaje/validation/generator/AdapterHelper.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/AdapterHelper.java
@@ -13,12 +13,30 @@ final class AdapterHelper {
   private final GenericType topType;
   private final GenericType genericType;
   private final boolean classLevel;
+  private final boolean crossParam;
 
   AdapterHelper(Append writer, ElementAnnotationContainer elementAnnotations, String indent) {
-    this(writer, elementAnnotations, indent,"Object", null, false);
+    this(writer, elementAnnotations, indent,"Object", null, false, false);
   }
 
-  AdapterHelper(Append writer, ElementAnnotationContainer elementAnnotations, String indent, String type, GenericType topType, boolean classLevel) {
+  AdapterHelper(
+      Append writer,
+      ElementAnnotationContainer elementAnnotations,
+      String indent,
+      String type,
+      GenericType topType,
+      boolean classLevel) {
+    this(writer, elementAnnotations, indent, type, topType, classLevel, false);
+  }
+
+  AdapterHelper(
+      Append writer,
+      ElementAnnotationContainer elementAnnotations,
+      String indent,
+      String type,
+      GenericType topType,
+      boolean classLevel,
+      boolean crossParam) {
     this.writer = writer;
     this.elementAnnotations = elementAnnotations;
     this.indent = indent;
@@ -26,13 +44,17 @@ final class AdapterHelper {
     this.topType = topType;
     this.genericType = elementAnnotations.genericType();
     this.classLevel = classLevel;
+    this.crossParam = crossParam;
   }
 
   void write() {
     final var typeUse1 = elementAnnotations.typeUse1();
     final var typeUse2 = elementAnnotations.typeUse2();
     final var hasValid = elementAnnotations.hasValid();
-    writeFirst(elementAnnotations.annotations());
+    writeFirst(crossParam ? elementAnnotations.crossParam() : elementAnnotations.annotations());
+    if (crossParam) {
+      return;
+    }
 
     if (!typeUse1.isEmpty() && (isAssignable2Interface(genericType.topType(), "java.lang.Iterable"))) {
       writer.eol().append("%s    .list()", indent);

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ConstraintPrism.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ConstraintPrism.java
@@ -9,6 +9,9 @@ import io.avaje.prism.GeneratePrism;
     name = "AvajeConstraintPrism",
     superInterfaces = ConstraintPrism.class)
 @GeneratePrism(
+    value = io.avaje.validation.CrossParamConstraint.class,
+    superInterfaces = ConstraintPrism.class)
+@GeneratePrism(
     value = jakarta.validation.Constraint.class,
     name = "JakartaConstraintPrism",
     superInterfaces = ConstraintPrism.class)
@@ -21,6 +24,7 @@ public interface ConstraintPrism {
   static boolean isPresent(Element e) {
     return AvajeConstraintPrism.isPresent(e)
         || JakartaConstraintPrism.isPresent(e)
-        || JavaxConstraintPrism.isPresent(e);
+        || JavaxConstraintPrism.isPresent(e)
+        || CrossParamConstraintPrism.isPresent(e);
   }
 }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/FieldReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/FieldReader.java
@@ -1,5 +1,7 @@
 package io.avaje.validation.generator;
 
+import static io.avaje.validation.generator.ProcessingContext.logError;
+
 import java.util.List;
 import java.util.Set;
 
@@ -133,7 +135,8 @@ final class FieldReader {
     } else if (publicField) {
       writer.append("value.%s%s", fieldName, suffix);
     } else {
-      throw new IllegalStateException(
+      logError(
+          element,
           "Field" + fieldName + " is inaccessible. Add a getter or make the field public.");
     }
   }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ValidMethodReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ValidMethodReader.java
@@ -28,7 +28,7 @@ final class ValidMethodReader {
     importTypes.add(diAnnotation());
     importTypes.add("java.util.Set");
     importTypes.add("java.util.Map");
-    importTypes.add("io.avaje.validation.inject.aspect.MethodAdapterProvider");
+    importTypes.add("io.avaje.validation.adapter.MethodAdapterProvider");
     importTypes.add("io.avaje.validation.adapter.ValidationAdapter");
     importTypes.add("io.avaje.validation.adapter.ValidationContext");
     importTypes.add("io.avaje.validation.spi.Generated");
@@ -108,6 +108,18 @@ final class ValidMethodReader {
     """);
     writer.append("    return ");
     new AdapterHelper(writer, returnElementAnnotation, "").write();
+
+    writer.append(
+        """
+        ;
+          }
+
+          @Override
+          public ValidationAdapter<Object[]> crossParamAdapter(ValidationContext ctx) {
+        """);
+    writer.append("    return ");
+
+    new AdapterHelper(writer, returnElementAnnotation, "", "Object[]", null, false, true).write();
 
     writer.append(";").eol();
     writer.append("  }").eol();

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/methods/Cross.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/methods/Cross.java
@@ -1,0 +1,11 @@
+package io.avaje.validation.generator.models.valid.methods;
+
+import io.avaje.validation.CrossParamConstraint;
+
+@CrossParamConstraint
+public @interface Cross {
+
+  String message() default "{io.avaje.validator.Cross}";
+
+  Class<?>[] groups() default {};
+}

--- a/validator-http-plugin/pom.xml
+++ b/validator-http-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-validator-parent</artifactId>
-    <version>1.0-RC2</version>
+    <version>1.0-RC3</version>
   </parent>
   <artifactId>avaje-validator-http-plugin</artifactId>
   <name>validator-http-plugin</name>

--- a/validator-inject-plugin/pom.xml
+++ b/validator-inject-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-validator-parent</artifactId>
-    <version>1.0-RC2</version>
+    <version>1.0-RC3</version>
   </parent>
   <artifactId>avaje-validator-inject-plugin</artifactId>
   <name>validator-inject-plugin</name>
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-validator</artifactId>
-      <version>0.13</version>
+      <version>1.0-RC3</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>

--- a/validator-inject-plugin/src/main/java/io/avaje/validation/inject/aspect/AOPMethodValidator.java
+++ b/validator-inject-plugin/src/main/java/io/avaje/validation/inject/aspect/AOPMethodValidator.java
@@ -11,6 +11,7 @@ import io.avaje.inject.PostConstruct;
 import io.avaje.inject.aop.AspectProvider;
 import io.avaje.inject.aop.MethodInterceptor;
 import io.avaje.validation.ValidMethod;
+import io.avaje.validation.adapter.MethodAdapterProvider;
 import io.avaje.validation.adapter.ValidationContext;
 
 public final class AOPMethodValidator implements AspectProvider<ValidMethod> {

--- a/validator-inject-plugin/src/main/java/io/avaje/validation/inject/aspect/ParamInterceptor.java
+++ b/validator-inject-plugin/src/main/java/io/avaje/validation/inject/aspect/ParamInterceptor.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import io.avaje.inject.aop.Invocation;
 import io.avaje.inject.aop.MethodInterceptor;
+import io.avaje.validation.adapter.MethodAdapterProvider;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidationContext;
 
@@ -18,6 +19,7 @@ final class ParamInterceptor implements MethodInterceptor {
   private final Locale locale;
   private final boolean throwOnParamFailure;
   private final Method method;
+  private ValidationAdapter<Object[]> crossParamAdapter;
 
   public ParamInterceptor(Locale locale, Method method, boolean throwOnParamFailure) {
 
@@ -38,6 +40,8 @@ final class ParamInterceptor implements MethodInterceptor {
       ++i;
     }
 
+    crossParamAdapter.validate(args, req);
+
     if (throwOnParamFailure) {
       req.throwWithViolations();
     }
@@ -53,5 +57,6 @@ final class ParamInterceptor implements MethodInterceptor {
     this.ctx = ctx;
     this.paramValidationAdapter = methodAdapterProvider.paramAdapters(ctx);
     this.returnValidationAdapter = methodAdapterProvider.returnAdapter(ctx);
+    this.crossParamAdapter = methodAdapterProvider.crossParamAdapter(ctx);
   }
 }

--- a/validator-inject-plugin/src/main/java/io/avaje/validation/inject/spi/DefaultValidatorProvider.java
+++ b/validator-inject-plugin/src/main/java/io/avaje/validation/inject/spi/DefaultValidatorProvider.java
@@ -12,8 +12,8 @@ import io.avaje.inject.aop.AspectProvider;
 import io.avaje.inject.spi.GenericType;
 import io.avaje.validation.ValidMethod;
 import io.avaje.validation.Validator;
+import io.avaje.validation.adapter.MethodAdapterProvider;
 import io.avaje.validation.inject.aspect.AOPMethodValidator;
-import io.avaje.validation.inject.aspect.MethodAdapterProvider;
 
 /** Plugin for avaje inject that provides a default Jsonb instance. */
 public final class DefaultValidatorProvider implements io.avaje.inject.spi.Plugin {

--- a/validator-inject-plugin/src/test/java/io/avaje/validation/inject/aspect/TestMethodValidation.java
+++ b/validator-inject-plugin/src/test/java/io/avaje/validation/inject/aspect/TestMethodValidation.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import io.avaje.validation.ConstraintViolationException;
 import io.avaje.validation.Validator;
+import io.avaje.validation.adapter.MethodAdapterProvider;
 import io.avaje.validation.adapter.ValidationContext;
 
 class TestMethodValidation {

--- a/validator-inject-plugin/src/test/java/io/avaje/validation/inject/aspect/TestParamProvider.java
+++ b/validator-inject-plugin/src/test/java/io/avaje/validation/inject/aspect/TestParamProvider.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 
 import io.avaje.inject.Component;
+import io.avaje.validation.adapter.MethodAdapterProvider;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidationContext;
 import io.avaje.validation.constraints.NotEmpty;

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-validator-parent</artifactId>
-    <version>1.0-RC2</version>
+    <version>1.0-RC3</version>
   </parent>
 
   <artifactId>avaje-validator</artifactId>
@@ -17,12 +17,6 @@
       <groupId>io.avaje</groupId>
       <artifactId>avaje-lang</artifactId>
       <version>1.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>io.avaje</groupId>
-      <artifactId>avaje-validator-http-plugin</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/validator/src/main/java/io/avaje/validation/CrossParamConstraint.java
+++ b/validator/src/main/java/io/avaje/validation/CrossParamConstraint.java
@@ -1,0 +1,12 @@
+package io.avaje.validation;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/** Marks an method annotation as a CrossParamConstraint. */
+@Retention(CLASS)
+@Target({ANNOTATION_TYPE})
+public @interface CrossParamConstraint {}

--- a/validator/src/main/java/io/avaje/validation/ValidMethod.java
+++ b/validator/src/main/java/io/avaje/validation/ValidMethod.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Target;
 
 import io.avaje.inject.aop.Aspect;
 
-@Aspect
+@Aspect(ordering = 10)
 @Target(METHOD)
 @Retention(RUNTIME)
 /** Place on a method to execute validations on the parameters and return types */

--- a/validator/src/main/java/io/avaje/validation/adapter/MethodAdapterProvider.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/MethodAdapterProvider.java
@@ -1,11 +1,9 @@
-package io.avaje.validation.inject.aspect;
+package io.avaje.validation.adapter;
 
 import java.lang.reflect.Method;
 import java.util.List;
 
 import io.avaje.inject.aop.InvocationException;
-import io.avaje.validation.adapter.ValidationAdapter;
-import io.avaje.validation.adapter.ValidationContext;
 
 public interface MethodAdapterProvider {
 
@@ -14,6 +12,10 @@ public interface MethodAdapterProvider {
   List<ValidationAdapter<Object>> paramAdapters(ValidationContext ctx);
 
   default ValidationAdapter<Object> returnAdapter(ValidationContext ctx) {
+    return ctx.noop();
+  }
+
+  default ValidationAdapter<Object[]> crossParamAdapter(ValidationContext ctx) {
     return ctx.noop();
   }
 

--- a/validator/src/main/java/io/avaje/validation/spi/BuilderCustomizer.java
+++ b/validator/src/main/java/io/avaje/validation/spi/BuilderCustomizer.java
@@ -5,9 +5,11 @@ import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+
 /**
- * Registers a type extending ValidatorCustomizer to {@code META-INF/services}, annotated types will
- * have an entry added to {@code META-INF/services/io.avaje.validation.adapter.ValidatorCustomizer}
+ * Registers a type extending {@link io.avaje.validation.spi.ValidatorCustomizer
+ * ValidatorCustomizer} to {@code META-INF/services}, annotated types will have an entry added to
+ * {@code META-INF/services/io.avaje.validation.adapter.ValidatorCustomizer}
  */
 @Retention(SOURCE)
 @Target(TYPE)


### PR DESCRIPTION
Now can do validation on all the methods arguments together

- move the MethodAdapterProvider interface into the main module (I forgot to do this earlier)
- adds a new method to retrieve the cross param adapters
- improve logging
- adds new annotation and corresponding generator changes
- disconnected the circle temporarily (MethodAdapterProvider was in a plugin)