### PR TITLE
Support primitive validation - limited to int,long with @Range initially

### DIFF
--- a/blackbox-test/src/test/java/example/avaje/range/APrimitiveLongRange.java
+++ b/blackbox-test/src/test/java/example/avaje/range/APrimitiveLongRange.java
@@ -4,10 +4,8 @@ import io.avaje.validation.constraints.Range;
 import jakarta.validation.Valid;
 
 @Valid
-public record ARange(
+public record APrimitiveLongRange(
   @Range(min = 1, max = 3)
-  int anIntVal,
-  @Range(min = 1, max = 3)
-  long aLongVal
+  long value
 ) {
 }

--- a/blackbox-test/src/test/java/example/avaje/range/APrimitiveTest.java
+++ b/blackbox-test/src/test/java/example/avaje/range/APrimitiveTest.java
@@ -1,0 +1,34 @@
+package example.avaje.range;
+
+import io.avaje.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class APrimitiveTest {
+
+  Validator validator = Validator.builder().build();
+
+  @Test
+  void rangeLongValid() {
+    validator.validate(new APrimitiveLongRange(1));
+    validator.validate(new APrimitiveLongRange(2));
+    validator.validate(new APrimitiveLongRange(3));
+  }
+
+  @Test
+  void rangeLongBelowMin() {
+    var violations  = new ArrayList<>(validator.check(new APrimitiveLongRange(0)));
+    assertThat(violations).hasSize(1);
+    assertThat(violations.get(0).message()).isEqualTo("must be between 1 and 3");
+  }
+
+  @Test
+  void rangeLongAboveMax() {
+    var violations  = new ArrayList<>(validator.check(new APrimitiveLongRange(4)));
+    assertThat(violations).hasSize(1);
+    assertThat(violations.get(0).message()).isEqualTo("must be between 1 and 3");
+  }
+}

--- a/validator-generator/src/main/java/io/avaje/validation/generator/AdapterHelper.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/AdapterHelper.java
@@ -14,6 +14,7 @@ final class AdapterHelper {
   private final GenericType genericType;
   private final boolean classLevel;
   private final boolean crossParam;
+  private boolean usePrimitiveValidation;
 
   AdapterHelper(Append writer, ElementAnnotationContainer elementAnnotations, String indent) {
     this(writer, elementAnnotations, indent,"Object", null, false, false);
@@ -47,12 +48,21 @@ final class AdapterHelper {
     this.crossParam = crossParam;
   }
 
+  AdapterHelper usePrimitiveValidation(boolean usePrimitiveValidation) {
+    this.usePrimitiveValidation = usePrimitiveValidation;
+    return this;
+  }
+
   void write() {
     final var typeUse1 = elementAnnotations.typeUse1();
     final var typeUse2 = elementAnnotations.typeUse2();
     final var hasValid = elementAnnotations.hasValid();
     writeFirst(crossParam ? elementAnnotations.crossParam() : elementAnnotations.annotations());
     if (crossParam) {
+      return;
+    }
+    if (usePrimitiveValidation) {
+      writer.eol().append("%s    .primitive()", indent);
       return;
     }
 

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
@@ -1,5 +1,6 @@
 package io.avaje.validation.generator;
 
+import static io.avaje.validation.generator.PrimitiveUtil.isPrimitiveValidationAnnotations;
 import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.toMap;
 
@@ -80,7 +81,6 @@ public record ElementAnnotationContainer(
   }
 
   static boolean hasMetaConstraintAnnotation(Element element) {
-
     return ConstraintPrism.isPresent(element);
   }
 
@@ -89,7 +89,6 @@ public record ElementAnnotationContainer(
 
   static ElementAnnotationContainer create(VariableElement varElement) {
     final var asString = varElement.asType().toString();
-
     final var noGeneric = AnnotationUtil.splitString(asString, "<")[0];
 
     final var annotations =
@@ -125,4 +124,14 @@ public record ElementAnnotationContainer(
   boolean isEmpty() {
     return annotations.isEmpty() && typeUse1.isEmpty() && typeUse2.isEmpty();
   }
+
+  boolean supportsPrimitiveValidation() {
+    for (GenericType validationAnnotation : annotations.keySet()) {
+      if (!isPrimitiveValidationAnnotations(validationAnnotation.shortName())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
 }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/PrimitiveUtil.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/PrimitiveUtil.java
@@ -7,7 +7,8 @@ import java.util.Set;
 final class PrimitiveUtil {
 
   private static final Set<String> primitiveValidationTypes = Set.of("int", "long");
-  private static final Set<String> primitiveValidationAnnotations = Set.of("Range");
+  private static final Set<String> primitiveValidationAnnotations =
+    Set.of("Range", "Min", "Max", "Positive", "PositiveOrZero", "Negative", "NegativeOrZero");
   private static final Map<String, String> wrapperMap = new HashMap<>();
 
   static {

--- a/validator-generator/src/main/java/io/avaje/validation/generator/PrimitiveUtil.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/PrimitiveUtil.java
@@ -2,10 +2,13 @@ package io.avaje.validation.generator;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 final class PrimitiveUtil {
 
-  static Map<String, String> wrapperMap = new HashMap<>();
+  private static final Set<String> primitiveValidationTypes = Set.of("int", "long");
+  private static final Set<String> primitiveValidationAnnotations = Set.of("Range");
+  private static final Map<String, String> wrapperMap = new HashMap<>();
 
   static {
     wrapperMap.put("char", "Character");
@@ -25,6 +28,14 @@ final class PrimitiveUtil {
 
   static boolean isPrimitive(String typeShortName) {
     return wrapperMap.containsKey(typeShortName);
+  }
+
+  static boolean isPrimitiveValidationType(String typeShortName) {
+    return primitiveValidationTypes.contains(typeShortName);
+  }
+
+  static boolean isPrimitiveValidationAnnotations(String annotationShortName) {
+    return primitiveValidationAnnotations.contains(annotationShortName);
   }
 
   static String defaultValue(String shortType) {

--- a/validator/src/main/java/io/avaje/validation/adapter/ValidationAdapter.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/ValidationAdapter.java
@@ -35,6 +35,13 @@ public interface ValidationAdapter<T> {
   }
 
   /**
+   * Return a primitive adapter. Supports int, long with Range, Min, Max, Positive.
+   */
+  default Primitive primitive() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Create an adapter for validating a list of values.
    *
    * @return The adapter for list validation
@@ -112,5 +119,21 @@ public interface ValidationAdapter<T> {
       }
     }
     return false;
+  }
+
+  /**
+   * Validation adapter that supports and uses the primitive type.
+   */
+  interface Primitive {
+
+    /**
+     * Validate using primitive int.
+     */
+    boolean validate(int value, ValidationRequest req, String propertyName);
+
+    /**
+     * Validate using primitive long.
+     */
+    boolean validate(long value, ValidationRequest req, String propertyName);
   }
 }


### PR DESCRIPTION
Generated code changes the type to `ValidationAdapter.Primitive` and uses `.primitive()` like:

```java
  private final ValidationAdapter.Primitive valueValidationAdapter;

  public APrimitiveLongRangeValidationAdapter(ValidationContext ctx) {
    this.valueValidationAdapter = 
        ctx.<Long>adapter(Range.class, Map.of("min",1L, "max",3L, "message","{avaje.Range.message}", "_type","Long"))
            .primitive();

  }

```