### PR TITLE
Support All Primitives

### DIFF
--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/AssertFalse.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/AssertFalse.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Target;
  *
  * @author Emmanuel Bernard
  */
-@Constraint
+@Constraint(unboxPrimitives = true)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 @Repeatable(AssertFalse.List.class)

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/AssertTrue.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/AssertTrue.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Target;
  *
  * @author Emmanuel Bernard
  */
-@Constraint
+@Constraint(unboxPrimitives = true)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 @Repeatable(AssertTrue.List.class)

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Constraint.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Constraint.java
@@ -11,4 +11,8 @@ import java.lang.annotation.Target;
  */
 @Retention(CLASS)
 @Target({ANNOTATION_TYPE})
-public @interface Constraint {}
+public @interface Constraint {
+
+  /** Determines if the constraint can validate primitives without boxing */
+  boolean unboxPrimitives() default false;
+}

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Max.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Max.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  *
  * @author Emmanuel Bernard
  */
-@Constraint
+@Constraint(unboxPrimitives = true)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 @Repeatable(Max.List.class)

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Min.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Min.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  *
  * @author Emmanuel Bernard
  */
-@Constraint
+@Constraint(unboxPrimitives = true)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 @Repeatable(Min.List.class)

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Negative.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Negative.java
@@ -31,7 +31,7 @@ import io.avaje.validation.constraints.Negative.List;
  *
  * @author Gunnar Morling
  */
-@Constraint
+@Constraint(unboxPrimitives = true)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
 @Retention(RUNTIME)
 @Repeatable(List.class)

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/NegativeOrZero.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/NegativeOrZero.java
@@ -30,7 +30,7 @@ import io.avaje.validation.constraints.NegativeOrZero.List;
  *
  * @author Gunnar Morling
  */
-@Constraint
+@Constraint(unboxPrimitives = true)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
 @Retention(RUNTIME)
 @Repeatable(List.class)

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Positive.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Positive.java
@@ -31,7 +31,7 @@ import io.avaje.validation.constraints.Positive.List;
  *
  * @author Gunnar Morling
  */
-@Constraint
+@Constraint(unboxPrimitives = true)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
 @Retention(RUNTIME)
 @Repeatable(List.class)

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/PositiveOrZero.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/PositiveOrZero.java
@@ -31,7 +31,7 @@ import io.avaje.validation.constraints.PositiveOrZero.List;
  * @author Gunnar Morling
  * @since 2.0
  */
-@Constraint
+@Constraint(unboxPrimitives = true)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
 @Retention(RUNTIME)
 @Repeatable(List.class)

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Range.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Range.java
@@ -21,7 +21,7 @@ import io.avaje.validation.constraints.Range.List;
  *
  * @author Hardy Ferentschik
  */
-@Constraint
+@Constraint(unboxPrimitives = true)
 @Documented
 @Retention(RUNTIME)
 @Repeatable(List.class)

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ConstraintPrism.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ConstraintPrism.java
@@ -1,5 +1,8 @@
 package io.avaje.validation.generator;
 
+import java.util.Optional;
+
+import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 
 import io.avaje.prism.GeneratePrism;
@@ -26,5 +29,18 @@ public interface ConstraintPrism {
         || JakartaConstraintPrism.isPresent(e)
         || JavaxConstraintPrism.isPresent(e)
         || CrossParamConstraintPrism.isPresent(e);
+  }
+
+  default Boolean unboxPrimitives() {
+    return false;
+  }
+
+  static Optional<ConstraintPrism> getOptionalOn(Element e) {
+
+    return Optional.<ConstraintPrism>empty()
+        .or(() -> AvajeConstraintPrism.getOptionalOn(e))
+        .or(() -> JakartaConstraintPrism.getOptionalOn(e))
+        .or(() -> JavaxConstraintPrism.getOptionalOn(e))
+        .or(() -> CrossParamConstraintPrism.getOptionalOn(e));
   }
 }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
@@ -1,6 +1,7 @@
 package io.avaje.validation.generator;
 
 import static io.avaje.validation.generator.PrimitiveUtil.isPrimitiveValidationAnnotations;
+import static io.avaje.validation.generator.ProcessingContext.element;
 import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.toMap;
 
@@ -126,12 +127,22 @@ public record ElementAnnotationContainer(
   }
 
   boolean supportsPrimitiveValidation() {
-    for (GenericType validationAnnotation : annotations.keySet()) {
+    for (final GenericType validationAnnotation : annotations.keySet()) {
+      final var type = validationAnnotation.topType();
+      ConstraintPrism.getOptionalOn(element(type))
+          .ifPresent(
+              p -> {
+                if (p.unboxPrimitives()) {
+                  validationAnnotation
+                      .shortName()
+                      .transform(PrimitiveUtil::addPrimitiveValidationAnnotation);
+                }
+              });
+
       if (!isPrimitiveValidationAnnotations(validationAnnotation.shortName())) {
         return false;
       }
     }
     return true;
   }
-
 }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/PrimitiveUtil.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/PrimitiveUtil.java
@@ -1,26 +1,43 @@
 package io.avaje.validation.generator;
 
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 final class PrimitiveUtil {
+  private PrimitiveUtil() {}
 
   private static final Set<String> primitiveValidationTypes = Set.of("int", "long");
   private static final Set<String> primitiveValidationAnnotations =
-    Set.of("Range", "Min", "Max", "Positive", "PositiveOrZero", "Negative", "NegativeOrZero");
-  private static final Map<String, String> wrapperMap = new HashMap<>();
-
-  static {
-    wrapperMap.put("char", "Character");
-    wrapperMap.put("byte", "Byte");
-    wrapperMap.put("int", "Integer");
-    wrapperMap.put("long", "Long");
-    wrapperMap.put("short", "Short");
-    wrapperMap.put("double", "Double");
-    wrapperMap.put("float", "Float");
-    wrapperMap.put("boolean", "Boolean");
-  }
+      new HashSet<>(
+          Set.of(
+              "AssertFalse",
+              "AssertTrue",
+              "Range",
+              "Min",
+              "Max",
+              "Positive",
+              "PositiveOrZero",
+              "Negative",
+              "NegativeOrZero"));
+  private static final Map<String, String> wrapperMap =
+      Map.of(
+          "char",
+          "Character",
+          "byte",
+          "Byte",
+          "int",
+          "Integer",
+          "long",
+          "Long",
+          "short",
+          "Short",
+          "double",
+          "Double",
+          "float",
+          "Float",
+          "boolean",
+          "Boolean");
 
   static String wrap(String shortName) {
     final String wrapped = wrapperMap.get(shortName);
@@ -37,6 +54,10 @@ final class PrimitiveUtil {
 
   static boolean isPrimitiveValidationAnnotations(String annotationShortName) {
     return primitiveValidationAnnotations.contains(annotationShortName);
+  }
+
+  static boolean addPrimitiveValidationAnnotation(String annotationShortName) {
+    return primitiveValidationAnnotations.add(annotationShortName);
   }
 
   static String defaultValue(String shortType) {

--- a/validator-generator/src/main/java/io/avaje/validation/generator/PrimitiveUtil.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/PrimitiveUtil.java
@@ -7,7 +7,6 @@ import java.util.Set;
 final class PrimitiveUtil {
   private PrimitiveUtil() {}
 
-  private static final Set<String> primitiveValidationTypes = Set.of("int", "long");
   private static final Set<String> primitiveValidationAnnotations =
       new HashSet<>(
           Set.of(
@@ -38,6 +37,7 @@ final class PrimitiveUtil {
           "Float",
           "boolean",
           "Boolean");
+  private static final Set<String> primitiveValidationTypes = wrapperMap.keySet();
 
   static String wrap(String shortName) {
     final String wrapped = wrapperMap.get(shortName);

--- a/validator-generator/src/main/java/io/avaje/validation/generator/Util.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/Util.java
@@ -271,7 +271,10 @@ final class Util {
   static String baseTypeOfAdapter(TypeElement element) {
 
     return Optional.of(element.getSuperclass())
-        .filter(t -> t.toString().contains("io.avaje.validation.adapter.AbstractConstraintAdapter"))
+        .filter(
+            t ->
+                t.toString().contains("io.avaje.validation.adapter.AbstractConstraintAdapter")
+                    || t.toString().contains("io.avaje.validation.adapter.PrimitiveAdapter"))
         .or(validationAdapter(element))
         .map(Object::toString)
         .map(GenericType::parse)
@@ -286,10 +289,32 @@ final class Util {
             });
   }
 
+  static boolean isPrimitiveAdapter(TypeElement element) {
+
+    return Optional.of(element.getSuperclass())
+        .filter(t -> t.toString().contains("io.avaje.validation.adapter.PrimitiveAdapter"))
+        .or(primitiveAdapter(element))
+        .isPresent();
+  }
+
   private static Supplier<Optional<? extends TypeMirror>> validationAdapter(TypeElement element) {
     return () ->
         element.getInterfaces().stream()
-            .filter(t -> t.toString().contains("io.avaje.validation.adapter.ValidationAdapter"))
+            .filter(
+                t ->
+                    t.toString().contains("io.avaje.validation.adapter.ValidationAdapter")
+                        || t.toString()
+                            .contains("io.avaje.validation.adapter.ValidationAdapter.Primitive"))
+            .findFirst();
+  }
+
+  private static Supplier<Optional<? extends TypeMirror>> primitiveAdapter(TypeElement element) {
+    return () ->
+        element.getInterfaces().stream()
+            .filter(
+                t ->
+                    t.toString()
+                        .contains("io.avaje.validation.adapter.ValidationAdapter.Primitive"))
             .findFirst();
   }
 

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ValidationProcessor.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ValidationProcessor.java
@@ -230,17 +230,6 @@ public final class ValidationProcessor extends AbstractProcessor {
   /** Read the beans that have changed. */
   private void writeConstraintAdapters(Set<? extends Element> beans) {
     ElementFilter.typesIn(beans).stream()
-        .peek(
-            t -> {
-              final var constraintPrism = ConstraintPrism.getOptionalOn(t).orElseThrow();
-              if (constraintPrism.unboxPrimitives()) {
-                t.asType()
-                    .toString()
-                    .transform(Util::trimAnnotations)
-                    .transform(Util::shortName)
-                    .transform(PrimitiveUtil::addPrimitiveValidationAnnotation);
-              }
-            })
         .filter(
             type ->
                 type.getAnnotationMirrors().stream()

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ValidationProcessor.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ValidationProcessor.java
@@ -76,9 +76,10 @@ public final class ValidationProcessor extends AbstractProcessor {
     getElements(round, AvajeConstraintPrism.PRISM_TYPE).ifPresent(this::writeConstraintAdapters);
     getElements(round, JavaxConstraintPrism.PRISM_TYPE).ifPresent(this::writeConstraintAdapters);
     getElements(round, JakartaConstraintPrism.PRISM_TYPE).ifPresent(this::writeConstraintAdapters);
-    getElements(round, CrossParamConstraintPrism.PRISM_TYPE).ifPresent(this::writeConstraintAdapters);
+    getElements(round, CrossParamConstraintPrism.PRISM_TYPE)
+        .ifPresent(this::writeConstraintAdapters);
 
-    //register custom adapters
+    // register custom adapters
     getElements(round, ConstraintAdapterPrism.PRISM_TYPE).ifPresent(this::registerCustomAdapters);
 
     getElements(round, AvajeValidPrism.PRISM_TYPE).ifPresent(this::writeAdapters);
@@ -89,26 +90,41 @@ public final class ValidationProcessor extends AbstractProcessor {
         .map(ElementFilter::methodsIn)
         .ifPresent(this::writeParamProviderForMethod);
 
-    writeAdaptersForImported(round.getElementsAnnotatedWith(element(ImportValidPojoPrism.PRISM_TYPE)));
+    writeAdaptersForImported(
+        round.getElementsAnnotatedWith(element(ImportValidPojoPrism.PRISM_TYPE)));
     initialiseComponent();
     cascadeTypes();
-    customizerServiceWriter.writeMetaInf(round.getElementsAnnotatedWith(element(BuilderCustomizerPrism.PRISM_TYPE)));
+    customizerServiceWriter.writeMetaInf(
+        round.getElementsAnnotatedWith(element(BuilderCustomizerPrism.PRISM_TYPE)));
     writeComponent(round.processingOver());
     return false;
   }
 
   // Optional because these annotations are not guaranteed to exist
-  private Optional<? extends Set<? extends Element>> getElements(RoundEnvironment round, String name) {
+  private Optional<? extends Set<? extends Element>> getElements(
+      RoundEnvironment round, String name) {
     return Optional.ofNullable(element(name)).map(round::getElementsAnnotatedWith);
   }
 
   private void registerCustomAdapters(Set<? extends Element> elements) {
     for (final var typeElement : ElementFilter.typesIn(elements)) {
       final var type = Util.baseTypeOfAdapter(typeElement);
-
-      if (!CrossParamConstraintPrism.getAllOnMetaAnnotations(typeElement).isEmpty() && type.contains("Object[]")) {
+      final var targetAnnotation =
+          asElement(ConstraintAdapterPrism.getInstanceOn(typeElement).value());
+      if (!CrossParamConstraintPrism.getAllOnMetaAnnotations(typeElement).isEmpty()
+          && type.contains("Object[]")) {
         logError(typeElement, "Cross Parameter Adapters must accept type Object[]");
       }
+
+      ConstraintPrism.getOptionalOn(targetAnnotation)
+          .ifPresent(
+              p -> {
+                if (p.unboxPrimitives() && !Util.isPrimitiveAdapter(typeElement)) {
+                  logError(
+                      typeElement,
+                      "Adapters for Primitive Constraints must extend PrimitiveAdapter or implement ValidationAdapter.Primitive");
+                }
+              });
 
       ElementFilter.constructorsIn(typeElement.getEnclosedElements()).stream()
           .filter(m -> m.getModifiers().contains(Modifier.PUBLIC))
@@ -153,7 +169,9 @@ public final class ValidationProcessor extends AbstractProcessor {
   }
 
   private boolean cascadeElement(TypeElement element) {
-    return element != null && element.getKind() != ElementKind.ENUM && !metaData.contains(adapterName(element));
+    return element != null
+        && element.getKind() != ElementKind.ENUM
+        && !metaData.contains(adapterName(element));
   }
 
   private String adapterName(TypeElement element) {
@@ -170,7 +188,8 @@ public final class ValidationProcessor extends AbstractProcessor {
   /** Elements that have a {@code @Valid.Import} annotation. */
   private void writeAdaptersForImported(Set<? extends Element> importedElements) {
     for (final var importedElement : ElementFilter.typesIn(importedElements)) {
-      for (final TypeMirror importType : ImportValidPojoPrism.getInstanceOn(importedElement).value()) {
+      for (final TypeMirror importType :
+          ImportValidPojoPrism.getInstanceOn(importedElement).value()) {
         // if imported by mixin annotation skip
         if (mixInImports.contains(importType.toString())) {
           continue;
@@ -211,6 +230,17 @@ public final class ValidationProcessor extends AbstractProcessor {
   /** Read the beans that have changed. */
   private void writeConstraintAdapters(Set<? extends Element> beans) {
     ElementFilter.typesIn(beans).stream()
+        .peek(
+            t -> {
+              final var constraintPrism = ConstraintPrism.getOptionalOn(t).orElseThrow();
+              if (constraintPrism.unboxPrimitives()) {
+                t.asType()
+                    .toString()
+                    .transform(Util::trimAnnotations)
+                    .transform(Util::shortName)
+                    .transform(PrimitiveUtil::addPrimitiveValidationAnnotation);
+              }
+            })
         .filter(
             type ->
                 type.getAnnotationMirrors().stream()
@@ -230,9 +260,9 @@ public final class ValidationProcessor extends AbstractProcessor {
 
   private boolean isController(TypeElement typeElement) {
     return typeElement.getAnnotationMirrors().stream()
-      .map(AnnotationMirror::getAnnotationType)
-      .map(DeclaredType::toString)
-      .anyMatch(val -> val.endsWith(".Controller"));
+        .map(AnnotationMirror::getAnnotationType)
+        .map(DeclaredType::toString)
+        .anyMatch(val -> val.endsWith(".Controller"));
   }
 
   private void writeAdapterForConstraint(TypeElement typeElement) {
@@ -269,7 +299,7 @@ public final class ValidationProcessor extends AbstractProcessor {
     for (final ExecutableElement executableElement : elements) {
       if (executableElement.getEnclosingElement().getAnnotationMirrors().stream()
           .map(m -> m.getAnnotationType().toString())
-          .noneMatch(annotationType -> isInjectableComponent(annotationType))) {
+          .noneMatch(ValidationProcessor::isInjectableComponent)) {
         logError(
             executableElement,
             "The ValidMethod Annotation can only be used with JSR-330 Injectable Classes");
@@ -280,9 +310,9 @@ public final class ValidationProcessor extends AbstractProcessor {
 
   private static boolean isInjectableComponent(String annotationType) {
     return annotationType.contains("Singleton")
-      || annotationType.contains("Component")
-      || annotationType.contains("Service")
-      || annotationType.contains("Controller");
+        || annotationType.contains("Component")
+        || annotationType.contains("Service")
+        || annotationType.contains("Controller");
   }
 
   private void writeParamProvider(ExecutableElement typeElement) {

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/Address.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/Address.java
@@ -2,8 +2,7 @@ package io.avaje.validation.generator.models.valid;
 
 public class Address {
 
-    public String line1;
-    public String line2;
-    public long longValue;
-
+  public String line1;
+  public String line2;
+  @PrimitiveTest public long longValue;
 }

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/PrimitiveTest.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/PrimitiveTest.java
@@ -1,0 +1,14 @@
+package io.avaje.validation.generator.models.valid;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import io.avaje.validation.constraints.Constraint;
+
+@Retention(SOURCE)
+@Target(FIELD)
+@Constraint(unboxPrimitives = true)
+public @interface PrimitiveTest {}

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/PrimitiveTestAdapter.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/PrimitiveTestAdapter.java
@@ -1,0 +1,18 @@
+package io.avaje.validation.generator.models.valid;
+
+import io.avaje.validation.adapter.ConstraintAdapter;
+import io.avaje.validation.adapter.PrimitiveAdapter;
+import io.avaje.validation.adapter.ValidationContext.AdapterCreateRequest;
+
+@ConstraintAdapter(PrimitiveTest.class)
+public final class PrimitiveTestAdapter extends PrimitiveAdapter<Long> {
+
+  public PrimitiveTestAdapter(AdapterCreateRequest request) {
+    super(request);
+  }
+
+  @Override
+  public boolean isValid(Long object) {
+    return false;
+  }
+}

--- a/validator/src/main/java/io/avaje/validation/ConstraintViolation.java
+++ b/validator/src/main/java/io/avaje/validation/ConstraintViolation.java
@@ -4,6 +4,4 @@ package io.avaje.validation;
  * Describes a constraint violation. This object exposes the constraint violation context as well as
  * the message describing the violation.
  */
-public record ConstraintViolation(String path, String field, String message) {
-
-}
+public record ConstraintViolation(String path, String field, String message) {}

--- a/validator/src/main/java/io/avaje/validation/adapter/MapValidationAdapter.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/MapValidationAdapter.java
@@ -6,7 +6,7 @@ final class MapValidationAdapter<T> extends AbstractContainerAdapter<T> {
 
   private final boolean keys;
 
-   MapValidationAdapter(ValidationAdapter<T> adapters, boolean keys) {
+  MapValidationAdapter(ValidationAdapter<T> adapters, boolean keys) {
     super(adapters);
     this.keys = keys;
   }

--- a/validator/src/main/java/io/avaje/validation/adapter/OptionalValidationAdapter.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/OptionalValidationAdapter.java
@@ -16,14 +16,15 @@ final class OptionalValidationAdapter<T> extends AbstractContainerAdapter<T> {
   public boolean validate(T value, ValidationRequest req, String propertyName) {
     if (value == null) {
       return true;
-    } else if (value instanceof final Optional<?> o) {
+    }
+    if (value instanceof final Optional<?> o) {
       o.ifPresent(v -> initalAdapter.validate((T) v, req, propertyName));
     } else if (value instanceof final OptionalInt i) {
-      i.ifPresent(v -> initalAdapter.validate(((T) (Object) v), req, propertyName));
+      i.ifPresent(v -> initalAdapter.validate((T) (Object) v, req, propertyName));
     } else if (value instanceof final OptionalLong l) {
-      l.ifPresent(v -> initalAdapter.validate(((T) (Object) v), req, propertyName));
+      l.ifPresent(v -> initalAdapter.validate((T) (Object) v, req, propertyName));
     } else if (value instanceof final OptionalDouble d) {
-      d.ifPresent(v -> initalAdapter.validate(((T) (Object) v), req, propertyName));
+      d.ifPresent(v -> initalAdapter.validate((T) (Object) v, req, propertyName));
     }
     return true;
   }

--- a/validator/src/main/java/io/avaje/validation/adapter/PrimitiveAdapter.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/PrimitiveAdapter.java
@@ -1,0 +1,149 @@
+package io.avaje.validation.adapter;
+
+import io.avaje.validation.adapter.ValidationContext.AdapterCreateRequest;
+
+public abstract class PrimitiveAdapter<T> extends AbstractConstraintAdapter<T>
+    implements ValidationAdapter.Primitive {
+
+  protected PrimitiveAdapter(AdapterCreateRequest request) {
+    super(request);
+  }
+
+  @Override
+  public final Primitive primitive() {
+    return this;
+  }
+
+  public boolean isValid(boolean value) {
+    throw unsupported("boolean");
+  }
+
+  public boolean isValid(byte value) {
+    throw unsupported("byte");
+  }
+
+  public boolean isValid(char value) {
+    throw unsupported("char");
+  }
+
+  public boolean isValid(double value) {
+    throw unsupported("double");
+  }
+
+  public boolean isValid(float value) {
+    throw unsupported("float");
+  }
+
+  public boolean isValid(int value) {
+    throw unsupported("int");
+  }
+
+  public boolean isValid(long value) {
+    throw unsupported("long");
+  }
+
+  public boolean isValid(short value) {
+    throw unsupported("short");
+  }
+
+  private UnsupportedOperationException unsupported(String type) {
+    return new UnsupportedOperationException(
+        "Validator " + toString() + " does not support primitive " + type);
+  }
+
+  @Override
+  public final boolean validate(boolean value, ValidationRequest req, String propertyName) {
+    if (!checkGroups(groups, req)) {
+      return true;
+    }
+    if (!isValid(value)) {
+      req.addViolation(message, propertyName);
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public final boolean validate(byte value, ValidationRequest req, String propertyName) {
+    if (!checkGroups(groups, req)) {
+      return true;
+    }
+    if (!isValid(value)) {
+      req.addViolation(message, propertyName);
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public final boolean validate(char value, ValidationRequest req, String propertyName) {
+    if (!checkGroups(groups, req)) {
+      return true;
+    }
+    if (!isValid(value)) {
+      req.addViolation(message, propertyName);
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public final boolean validate(double value, ValidationRequest req, String propertyName) {
+    if (!checkGroups(groups, req)) {
+      return true;
+    }
+    if (!isValid(value)) {
+      req.addViolation(message, propertyName);
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public final boolean validate(float value, ValidationRequest req, String propertyName) {
+    if (!checkGroups(groups, req)) {
+      return true;
+    }
+    if (!isValid(value)) {
+      req.addViolation(message, propertyName);
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public final boolean validate(int value, ValidationRequest req, String propertyName) {
+    if (!checkGroups(groups, req)) {
+      return true;
+    }
+    if (!isValid(value)) {
+      req.addViolation(message, propertyName);
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public final boolean validate(long value, ValidationRequest req, String propertyName) {
+    if (!checkGroups(groups, req)) {
+      return true;
+    }
+    if (!isValid(value)) {
+      req.addViolation(message, propertyName);
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public final boolean validate(short value, ValidationRequest req, String propertyName) {
+    if (!checkGroups(groups, req)) {
+      return true;
+    }
+    if (!isValid(value)) {
+      req.addViolation(message, propertyName);
+      return false;
+    }
+    return true;
+  }
+}

--- a/validator/src/main/java/io/avaje/validation/adapter/RegexFlag.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/RegexFlag.java
@@ -59,9 +59,7 @@ public enum RegexFlag {
     this.value = value;
   }
 
-  /**
-   * @return flag value as defined in {@link java.util.regex.Pattern}
-   */
+  /** @return flag value as defined in {@link java.util.regex.Pattern} */
   public int getValue() {
     return value;
   }

--- a/validator/src/main/java/io/avaje/validation/adapter/ValidationAdapter.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/ValidationAdapter.java
@@ -34,9 +34,7 @@ public interface ValidationAdapter<T> {
     return validate(value, req, null);
   }
 
-  /**
-   * Return a primitive adapter. Supports int, long with Range, Min, Max, Positive.
-   */
+  /** Return a primitive adapter. Supports int, long with Range, Min, Max, Positive. */
   default Primitive primitive() {
     throw new UnsupportedOperationException();
   }
@@ -121,19 +119,31 @@ public interface ValidationAdapter<T> {
     return false;
   }
 
-  /**
-   * Validation adapter that supports and uses the primitive type.
-   */
+  /** Validation adapter that supports and uses the primitive type. */
   interface Primitive {
 
-    /**
-     * Validate using primitive int.
-     */
+    /** Validate using primitive boolean. */
+    boolean validate(boolean value, ValidationRequest req, String propertyName);
+
+    /** Validate using primitive byte. */
+    boolean validate(byte value, ValidationRequest req, String propertyName);
+
+    /** Validate using primitive char. */
+    boolean validate(char value, ValidationRequest req, String propertyName);
+
+    /** Validate using primitive double. */
+    boolean validate(double value, ValidationRequest req, String propertyName);
+
+    /** Validate using primitive float. */
+    boolean validate(float value, ValidationRequest req, String propertyName);
+
+    /** Validate using primitive int. */
     boolean validate(int value, ValidationRequest req, String propertyName);
 
-    /**
-     * Validate using primitive long.
-     */
+    /** Validate using primitive long. */
     boolean validate(long value, ValidationRequest req, String propertyName);
+
+    /** Validate using primitive short. */
+    boolean validate(short value, ValidationRequest req, String propertyName);
   }
 }

--- a/validator/src/main/java/io/avaje/validation/core/DValidator.java
+++ b/validator/src/main/java/io/avaje/validation/core/DValidator.java
@@ -317,7 +317,7 @@ final class DValidator implements Validator, ValidationContext {
         Type type, ValidationAdapter<T> adapter) {
       requireNonNull(type);
       requireNonNull(adapter);
-      return (request) -> simpleMatch(type, request.annotationType()) ? adapter : null;
+      return request -> simpleMatch(type, request.annotationType()) ? adapter : null;
     }
 
     private static <T> AdapterFactory newAdapterFactory(Type type, ValidationAdapter<T> adapter) {
@@ -336,7 +336,7 @@ final class DValidator implements Validator, ValidationContext {
         Class<? extends Annotation> type, AnnotationAdapterBuilder builder) {
       requireNonNull(type);
       requireNonNull(builder);
-      return (req) -> simpleMatch(type, req.annotationType()) ? builder.build(req) : null;
+      return req -> simpleMatch(type, req.annotationType()) ? builder.build(req) : null;
     }
 
     private static boolean simpleMatch(Type type, Type targetType) {

--- a/validator/src/main/java/io/avaje/validation/core/LocaleResolver.java
+++ b/validator/src/main/java/io/avaje/validation/core/LocaleResolver.java
@@ -28,8 +28,7 @@ final class LocaleResolver {
   public Locale resolve(@Nullable Locale requestLocale) {
     if (requestLocale == null || !otherLocales.contains(requestLocale)) {
       return defaultLocale;
-    } else {
-      return requestLocale;
     }
+    return requestLocale;
   }
 }

--- a/validator/src/main/java/io/avaje/validation/core/adapters/BasicAdapters.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/BasicAdapters.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import io.avaje.validation.adapter.AbstractConstraintAdapter;
+import io.avaje.validation.adapter.PrimitiveAdapter;
 import io.avaje.validation.adapter.RegexFlag;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidationContext;
@@ -22,8 +23,8 @@ public final class BasicAdapters {
             case "URI" -> new UriAdapter(request);
             case "Null" -> new NullableAdapter(request, true);
             case "NotNull", "NonNull" -> new NullableAdapter(request, false);
-            case "AssertTrue" -> new AssertBooleanAdapter(request, Boolean.TRUE);
-            case "AssertFalse" -> new AssertBooleanAdapter(request, Boolean.FALSE);
+            case "AssertTrue" -> new AssertBooleanAdapter(request, true);
+            case "AssertFalse" -> new AssertBooleanAdapter(request, false);
             case "NotBlank" -> new NotBlankAdapter(request);
             case "NotEmpty" -> new NotEmptyAdapter(request);
             case "Pattern" -> new PatternAdapter(request);
@@ -209,18 +210,23 @@ public final class BasicAdapters {
     }
   }
 
-  private static final class AssertBooleanAdapter extends AbstractConstraintAdapter<Boolean> {
+  private static final class AssertBooleanAdapter extends PrimitiveAdapter<Boolean> {
 
-    private final Boolean assertBool;
+    private final boolean assertBool;
 
-    AssertBooleanAdapter(AdapterCreateRequest request, Boolean assertBool) {
+    AssertBooleanAdapter(AdapterCreateRequest request, boolean assertBool) {
       super(request);
       this.assertBool = assertBool;
     }
 
     @Override
     public boolean isValid(Boolean type) {
-      return !assertBool.booleanValue() && type == null || assertBool.equals(type);
+      return !assertBool && type == null || type != null && assertBool == type.booleanValue();
+    }
+
+    @Override
+    public boolean isValid(boolean type) {
+      return assertBool == type;
     }
   }
 

--- a/validator/src/main/java/io/avaje/validation/core/adapters/FuturePastAdapterFactory.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/FuturePastAdapterFactory.java
@@ -24,14 +24,10 @@ public final class FuturePastAdapterFactory implements AnnotationFactory {
   @Override
   public ValidationAdapter<?> create(AdapterCreateRequest request) {
     return switch (request.annotationType().getSimpleName()) {
-      case "Past" -> new FuturePastAdapter(
-          request, true, false, pastClock());
-      case "PastOrPresent" -> new FuturePastAdapter(
-          request, true, true, pastClock());
-      case "Future" -> new FuturePastAdapter(
-          request, false, false, futureClock());
-      case "FutureOrPresent" -> new FuturePastAdapter(
-          request, false, true, futureClock());
+      case "Past" -> new FuturePastAdapter(request, true, false, pastClock());
+      case "PastOrPresent" -> new FuturePastAdapter(request, true, true, pastClock());
+      case "Future" -> new FuturePastAdapter(request, false, false, futureClock());
+      case "FutureOrPresent" -> new FuturePastAdapter(request, false, true, futureClock());
       default -> null;
     };
   }

--- a/validator/src/main/java/io/avaje/validation/core/adapters/InfinityNumberComparatorHelper.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/InfinityNumberComparatorHelper.java
@@ -2,9 +2,7 @@ package io.avaje.validation.core.adapters;
 
 import java.util.OptionalInt;
 
-/**
- * @author Marko Bekhta
- */
+/** @author Marko Bekhta */
 final class InfinityNumberComparatorHelper {
 
   static final OptionalInt LESS_THAN = OptionalInt.of(-1);

--- a/validator/src/main/java/io/avaje/validation/core/adapters/NumberAdapters.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/NumberAdapters.java
@@ -444,6 +444,29 @@ public final class NumberAdapters {
     }
 
     @Override
+    public boolean isValid(Number value) {
+      if (value == null) {
+        return true;
+      }
+      return minAdapter.isValid(value) && maxAdapter.isValid(value);
+    }
+
+    @Override
+    public boolean isValid(byte value) {
+      return value >= min && value <= max;
+    }
+
+    @Override
+    public boolean isValid(double value) {
+      return value >= min && value <= max;
+    }
+
+    @Override
+    public boolean isValid(float value) {
+      return value >= min && value <= max;
+    }
+
+    @Override
     public boolean isValid(int value) {
       return value >= min && value <= max;
     }
@@ -454,11 +477,8 @@ public final class NumberAdapters {
     }
 
     @Override
-    public boolean isValid(Number value) {
-      if (value == null) {
-        return true;
-      }
-      return minAdapter.isValid(value) && maxAdapter.isValid(value);
+    public boolean isValid(short value) {
+      return value >= min && value <= max;
     }
   }
 

--- a/validator/src/main/java/io/avaje/validation/core/adapters/NumberAdapters.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/NumberAdapters.java
@@ -10,28 +10,29 @@ import java.math.BigInteger;
 import java.util.Optional;
 
 import io.avaje.validation.adapter.AbstractConstraintAdapter;
+import io.avaje.validation.adapter.PrimitiveAdapter;
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidationContext;
 import io.avaje.validation.adapter.ValidationContext.AdapterCreateRequest;
-import io.avaje.validation.adapter.ValidationRequest;
 
 public final class NumberAdapters {
   private NumberAdapters() {}
 
   public static final ValidationContext.AnnotationFactory FACTORY =
-    request -> switch (request.annotationType().getSimpleName()) {
-    case "Digits" -> new DigitsAdapter(request);
-    case "Positive" -> new PositiveAdapter(request, false);
-    case "PositiveOrZero" -> new PositiveAdapter(request, true);
-    case "Negative" -> new NegativeAdapter(request, false);
-    case "NegativeOrZero" -> new NegativeAdapter(request, true);
-    case "Max" -> max(request);
-    case "Min" -> min(request);
-    case "DecimalMax" -> new DecimalMaxAdapter(request);
-    case "DecimalMin" -> new DecimalMinAdapter(request);
-    case "Range" -> range(request);
-    default -> null;
-  };
+      request ->
+          switch (request.annotationType().getSimpleName()) {
+            case "Digits" -> new DigitsAdapter(request);
+            case "Positive" -> new PositiveAdapter(request, false);
+            case "PositiveOrZero" -> new PositiveAdapter(request, true);
+            case "Negative" -> new NegativeAdapter(request, false);
+            case "NegativeOrZero" -> new NegativeAdapter(request, true);
+            case "Max" -> max(request);
+            case "Min" -> min(request);
+            case "DecimalMax" -> new DecimalMaxAdapter(request);
+            case "DecimalMin" -> new DecimalMinAdapter(request);
+            case "Range" -> range(request);
+            default -> null;
+          };
 
   private static ValidationAdapter<?> range(AdapterCreateRequest request) {
     if ("String".equals(request.targetType())) {
@@ -78,7 +79,8 @@ public final class NumberAdapters {
       if (number == null) {
         return true;
       }
-      final int comparisonResult = NumberComparatorHelper.compareDecimal(targetType, number, value, LESS_THAN);
+      final int comparisonResult =
+          NumberComparatorHelper.compareDecimal(targetType, number, value, LESS_THAN);
       return !(inclusive ? comparisonResult > 0 : comparisonResult >= 0);
     }
   }
@@ -103,7 +105,8 @@ public final class NumberAdapters {
       if (number == null) {
         return true;
       }
-      final int comparisonResult = NumberComparatorHelper.compareDecimal(targetType, number, value, LESS_THAN);
+      final int comparisonResult =
+          NumberComparatorHelper.compareDecimal(targetType, number, value, LESS_THAN);
       return !(inclusive ? comparisonResult < 0 : comparisonResult <= 0);
     }
   }
@@ -112,7 +115,8 @@ public final class NumberAdapters {
     boolean isValid(T number);
   }
 
-  private static final class MaxAdapter extends PrimitiveAdapter<Number> implements NumberAdapter<Number> {
+  private static final class MaxAdapter extends PrimitiveAdapter<Number>
+      implements NumberAdapter<Number> {
 
     private final long max;
     private final String targetType;
@@ -124,16 +128,6 @@ public final class NumberAdapters {
     }
 
     @Override
-    boolean isValid(int value) {
-      return value <= max;
-    }
-
-    @Override
-    boolean isValid(long value) {
-      return value <= max;
-    }
-
-    @Override
     public boolean isValid(Number number) {
       // null values are valid
       if (number == null) {
@@ -141,14 +135,45 @@ public final class NumberAdapters {
       }
       return switch (targetType) {
         case "Integer", "Long", "Short", "Byte" -> number.longValue() <= max;
-        case "Double", "Number" -> compareDouble(number.doubleValue(), max, GREATER_THAN)  <= 0;
-        case "Float" -> compareFloat((Float)number, max, GREATER_THAN)  <= 0;
+        case "Double", "Number" -> compareDouble(number.doubleValue(), max, GREATER_THAN) <= 0;
+        case "Float" -> compareFloat((Float) number, max, GREATER_THAN) <= 0;
         default -> throw new IllegalStateException();
       };
     }
+
+    @Override
+    public boolean isValid(byte value) {
+      return value <= max;
+    }
+
+    @Override
+    public boolean isValid(double value) {
+      return value <= max;
+    }
+
+    @Override
+    public boolean isValid(float value) {
+      return value <= max;
+    }
+
+    @Override
+    public boolean isValid(int value) {
+      return value <= max;
+    }
+
+    @Override
+    public boolean isValid(long value) {
+      return value <= max;
+    }
+
+    @Override
+    public boolean isValid(short value) {
+      return value <= max;
+    }
   }
 
-  static final class MaxBigDecimal extends AbstractConstraintAdapter<BigDecimal> implements NumberAdapter<BigDecimal> {
+  static final class MaxBigDecimal extends AbstractConstraintAdapter<BigDecimal>
+      implements NumberAdapter<BigDecimal> {
 
     private final BigDecimal max;
 
@@ -163,7 +188,8 @@ public final class NumberAdapters {
     }
   }
 
-  static final class MaxBigInteger extends AbstractConstraintAdapter<BigInteger> implements NumberAdapter<BigInteger> {
+  static final class MaxBigInteger extends AbstractConstraintAdapter<BigInteger>
+      implements NumberAdapter<BigInteger> {
 
     private final BigInteger max;
 
@@ -178,7 +204,8 @@ public final class NumberAdapters {
     }
   }
 
-  private static final class MinAdapter extends PrimitiveAdapter<Number> implements NumberAdapter<Number> {
+  private static final class MinAdapter extends PrimitiveAdapter<Number>
+      implements NumberAdapter<Number> {
 
     private final long min;
     private final String targetType;
@@ -190,30 +217,51 @@ public final class NumberAdapters {
     }
 
     @Override
-    boolean isValid(int value) {
-      return value >= min;
-    }
-
-    @Override
-    boolean isValid(long value) {
-      return value >= min;
-    }
-
-    @Override
     public boolean isValid(Number number) {
       if (number == null) {
         return true;
       }
       return switch (targetType) {
         case "Integer", "Long", "Short", "Byte" -> number.longValue() >= min;
-        case "Double" -> compareDouble(number.doubleValue(), min, LESS_THAN)  >= 0;
-        case "Float" -> compareFloat((Float)number, min, LESS_THAN)  >= 0;
+        case "Double" -> compareDouble(number.doubleValue(), min, LESS_THAN) >= 0;
+        case "Float" -> compareFloat((Float) number, min, LESS_THAN) >= 0;
         default -> throw new IllegalStateException();
       };
     }
+
+    @Override
+    public boolean isValid(byte value) {
+      return value >= min;
+    }
+
+    @Override
+    public boolean isValid(double value) {
+      return value >= min;
+    }
+
+    @Override
+    public boolean isValid(float value) {
+      return value >= min;
+    }
+
+    @Override
+    public boolean isValid(int value) {
+      return value >= min;
+    }
+
+    @Override
+    public boolean isValid(long value) {
+      return value >= min;
+    }
+
+    @Override
+    public boolean isValid(short value) {
+      return value >= min;
+    }
   }
 
-  static final class MinBigDecimal extends AbstractConstraintAdapter<BigDecimal> implements NumberAdapter<BigDecimal> {
+  static final class MinBigDecimal extends AbstractConstraintAdapter<BigDecimal>
+      implements NumberAdapter<BigDecimal> {
 
     private final BigDecimal min;
 
@@ -228,7 +276,8 @@ public final class NumberAdapters {
     }
   }
 
-  static final class MinBigInteger extends AbstractConstraintAdapter<BigInteger> implements NumberAdapter<BigInteger> {
+  static final class MinBigInteger extends AbstractConstraintAdapter<BigInteger>
+      implements NumberAdapter<BigInteger> {
 
     private final BigInteger min;
 
@@ -296,12 +345,32 @@ public final class NumberAdapters {
     }
 
     @Override
-    boolean isValid(int value) {
+    public boolean isValid(byte value) {
       return inclusive ? value >= 0 : value > 0;
     }
 
     @Override
-    boolean isValid(long value) {
+    public boolean isValid(double value) {
+      return inclusive ? value >= 0 : value > 0;
+    }
+
+    @Override
+    public boolean isValid(float value) {
+      return inclusive ? value >= 0 : value > 0;
+    }
+
+    @Override
+    public boolean isValid(int value) {
+      return inclusive ? value >= 0 : value > 0;
+    }
+
+    @Override
+    public boolean isValid(long value) {
+      return inclusive ? value >= 0 : value > 0;
+    }
+
+    @Override
+    public boolean isValid(short value) {
       return inclusive ? value >= 0 : value > 0;
     }
   }
@@ -328,12 +397,32 @@ public final class NumberAdapters {
     }
 
     @Override
-    boolean isValid(int value) {
+    public boolean isValid(byte value) {
       return inclusive ? value <= 0 : value < 0;
     }
 
     @Override
-    boolean isValid(long value) {
+    public boolean isValid(double value) {
+      return inclusive ? value <= 0 : value < 0;
+    }
+
+    @Override
+    public boolean isValid(float value) {
+      return inclusive ? value <= 0 : value < 0;
+    }
+
+    @Override
+    public boolean isValid(int value) {
+      return inclusive ? value <= 0 : value < 0;
+    }
+
+    @Override
+    public boolean isValid(long value) {
+      return inclusive ? value <= 0 : value < 0;
+    }
+
+    @Override
+    public boolean isValid(short value) {
       return inclusive ? value <= 0 : value < 0;
     }
   }
@@ -355,12 +444,12 @@ public final class NumberAdapters {
     }
 
     @Override
-    boolean isValid(int value) {
+    public boolean isValid(int value) {
       return value >= min && value <= max;
     }
 
     @Override
-    boolean isValid(long value) {
+    public boolean isValid(long value) {
       return value >= min && value <= max;
     }
 
@@ -370,46 +459,6 @@ public final class NumberAdapters {
         return true;
       }
       return minAdapter.isValid(value) && maxAdapter.isValid(value);
-    }
-  }
-
-  private static abstract class PrimitiveAdapter<T> extends AbstractConstraintAdapter<T> implements ValidationAdapter.Primitive {
-
-    PrimitiveAdapter(AdapterCreateRequest request) {
-      super(request);
-    }
-
-    @Override
-    public final Primitive primitive() {
-      return this;
-    }
-
-    abstract boolean isValid(int value);
-
-    abstract boolean isValid(long value);
-
-    @Override
-    public final boolean validate(int value, ValidationRequest req, String propertyName) {
-      if (!checkGroups(groups, req)) {
-        return true;
-      }
-      if (!isValid(value)) {
-        req.addViolation(message, propertyName);
-        return false;
-      }
-      return true;
-    }
-
-    @Override
-    public final boolean validate(long value, ValidationRequest req, String propertyName) {
-      if (!checkGroups(groups, req)) {
-        return true;
-      }
-      if (!isValid(value)) {
-        req.addViolation(message, propertyName);
-        return false;
-      }
-      return true;
     }
   }
 

--- a/validator/src/main/java/io/avaje/validation/core/adapters/NumberAdapters.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/NumberAdapters.java
@@ -37,9 +37,8 @@ public final class NumberAdapters {
   private static ValidationAdapter<?> range(AdapterCreateRequest request) {
     if ("String".equals(request.targetType())) {
       return new RangeStringAdapter(request);
-    } else {
-      return new RangeAdapter(request);
     }
+    return new RangeAdapter(request);
   }
 
   private static AbstractConstraintAdapter<? extends Number> max(AdapterCreateRequest request) {
@@ -319,7 +318,7 @@ public final class NumberAdapters {
 
       final int integerPartLength = bigNum.precision() - bigNum.scale();
       final int fractionPartLength = Math.max(bigNum.scale(), 0);
-      return (integer >= integerPartLength) && (fraction >= fractionPartLength);
+      return integer >= integerPartLength && fraction >= fractionPartLength;
     }
   }
 

--- a/validator/src/main/java/io/avaje/validation/core/adapters/NumberComparatorHelper.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/NumberComparatorHelper.java
@@ -18,7 +18,8 @@ final class NumberComparatorHelper {
       case "Float" -> compareFloat((Float) number, value, treatNanAs);
       case "BigDecimal" -> ((BigDecimal) number).compareTo(value);
       case "BigInteger" -> new BigDecimal((BigInteger) number).compareTo(value);
-      case "Byte", "Integer", "Long", "Short" -> BigDecimal.valueOf(((Number)number).longValue()).compareTo(value);
+      case "Byte", "Integer", "Long", "Short" -> BigDecimal.valueOf(((Number) number).longValue())
+          .compareTo(value);
       default -> compareDecimal(number, value, treatNanAs);
     };
   }
@@ -26,9 +27,8 @@ final class NumberComparatorHelper {
   private static int compareDecimal(Object number, BigDecimal value, OptionalInt treatNanAs) {
     if (number instanceof Number n) {
       return compareDouble(n.doubleValue(), value, treatNanAs);
-    } else {
-      return new BigDecimal(number.toString()).compareTo(value);
     }
+    return new BigDecimal(number.toString()).compareTo(value);
   }
 
   static int compareDouble(Double number, long value, OptionalInt treatNanAs) {

--- a/validator/src/main/java/io/avaje/validation/core/adapters/UriAdapter.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/UriAdapter.java
@@ -1,12 +1,12 @@
 package io.avaje.validation.core.adapters;
 
+import java.net.URI;
+
 import io.avaje.validation.adapter.AbstractConstraintAdapter;
 import io.avaje.validation.adapter.ValidationContext.AdapterCreateRequest;
 import io.avaje.validation.core.adapters.BasicAdapters.PatternAdapter;
 
-import java.net.URI;
-
-final class UriAdapter extends AbstractConstraintAdapter {
+final class UriAdapter extends AbstractConstraintAdapter<Object> {
 
   private final String scheme;
   private final String host;
@@ -20,7 +20,7 @@ final class UriAdapter extends AbstractConstraintAdapter {
     this.host = (String) request.attribute("host");
     this.port = (int) request.attribute("port");
 
-    String regexp = (String) request.attribute("regexp");
+    final String regexp = (String) request.attribute("regexp");
     if (!regexp.isEmpty()) {
       patternAdapter = new PatternAdapter(request);
     } else {
@@ -36,10 +36,8 @@ final class UriAdapter extends AbstractConstraintAdapter {
     try {
       final var stringValue = String.valueOf(value);
       final var uri = URI.create(stringValue);
-      if (!scheme.isEmpty() && !scheme.equals(uri.getScheme())) {
-        return false;
-      }
-      if (!host.isEmpty() && !host.equals(uri.getHost())) {
+      if (!scheme.isEmpty() && !scheme.equals(uri.getScheme())
+          || !host.isEmpty() && !host.equals(uri.getHost())) {
         return false;
       }
       if (port > -1 && port != uri.getPort()) {


### PR DESCRIPTION
- Modifies ValidationAdapter.Primitive to have methods for all primitives
- adds a new property to `@Constraint` to signal whether the annotation should accept primitives
- modifies generation to read the constraint annotation property and add to the list of primitive adapters
- Move primitive adapter to public package
- modify basic and number adapters