### PR TITLE
Warn against Jlink errors

### DIFF
--- a/validator-generator/src/main/java/io/avaje/validation/generator/ProcessingContext.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ProcessingContext.java
@@ -163,22 +163,20 @@ final class ProcessingContext {
                 .toString();
         try (var inputStream = new URI(resource).toURL().openStream();
             var reader = new BufferedReader(new InputStreamReader(inputStream))) {
-        	 AtomicBoolean noInjectPlugin = new AtomicBoolean(injectPresent);
-        	 AtomicBoolean noHttpPlugin = new AtomicBoolean(warnHttp);
+          AtomicBoolean noInjectPlugin = new AtomicBoolean(injectPresent);
+          AtomicBoolean noHttpPlugin = new AtomicBoolean(warnHttp);
           var noProvides =
               reader
                   .lines()
                   .map(
                       s -> {
-                        if (injectPresent
-                            && s.contains("io.avaje.validation.plugin")) {
+                        if (injectPresent && s.contains("io.avaje.validation.plugin")) {
                           noInjectPlugin.set(false);
                         }
 
-                        if (injectPresent
-                            && s.contains("io.avaje.validation.http")) {
-                            noInjectPlugin.set(false);
-                            noHttpPlugin.set(false);
+                        if (injectPresent && warnHttp && s.contains("io.avaje.validation.http")) {
+                          noInjectPlugin.set(false);
+                          noHttpPlugin.set(false);
                         }
 
                         return s;

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ProcessingContext.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ProcessingContext.java
@@ -186,7 +186,7 @@ final class ProcessingContext {
           if (noProvides) {
             logError(
                 module,
-                "Missing \"provides io.avaje.validation.Validator.GeneratedComponent with %s;\"",
+                "Missing `provides io.avaje.validation.Validator.GeneratedComponent with %s;`",
                 fqn);
           }
 


### PR DESCRIPTION
Will add a compile warning if people use avaje-http or avaje-inject and forget to add the plugins to the module-info.