### PR TITLE
Don't register a field unless it has constraints

### DIFF
--- a/validator-generator/src/main/java/io/avaje/validation/generator/FieldReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/FieldReader.java
@@ -199,7 +199,7 @@ final class FieldReader {
     return classLevel;
   }
 
-  public boolean hasAnnotations() {
+  public boolean hasConstraints() {
     return !elementAnnotations.isEmpty();
   }
 }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/TypeReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/TypeReader.java
@@ -59,7 +59,7 @@ final class TypeReader {
     }
 
     final var classAdapter = new FieldReader(type, genericTypeParams, true);
-    if (classAdapter.hasAnnotations()) {
+    if (classAdapter.hasConstraints()) {
       localFields.add(classAdapter);
     }
 
@@ -72,7 +72,10 @@ final class TypeReader {
   private void readField(Element element, List<FieldReader> localFields) {
     if (includeField(element)) {
       seenFields.add(element.toString());
-      localFields.add(new FieldReader(element, genericTypeParams));
+      var reader = new FieldReader(element, genericTypeParams);
+      if (reader.hasConstraints() || ValidPrism.isPresent(element)) {
+        localFields.add(reader);
+      }
     }
   }
 


### PR DESCRIPTION
Fix cases where non-accessible fields with non-constraint annotations would prevent validator generation.