### PR TITLE
Remove Hard Dependency on Http-API

### DIFF
--- a/validator-http-plugin/src/main/java/io/avaje/validation/http/HttpValidatorProvider.java
+++ b/validator-http-plugin/src/main/java/io/avaje/validation/http/HttpValidatorProvider.java
@@ -4,23 +4,35 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Locale;
 
-import io.avaje.http.api.Validator;
 import io.avaje.inject.BeanScopeBuilder;
 
 /** Plugin for avaje inject that provides a default Http Validator instance. */
 public final class HttpValidatorProvider implements io.avaje.inject.spi.Plugin {
 
+  private static final Class<?> VALIDATOR_HTTP_CLASS = httpOnCp();
+
+  private static Class<?> httpOnCp() {
+    try {
+      return Class.forName("io.avaje.http.api.Validator");
+    } catch (ClassNotFoundException e) {
+      return null;
+    }
+  }
+
   @Override
   public Class<?>[] provides() {
-    return new Class<?>[] {Validator.class};
+    return VALIDATOR_HTTP_CLASS == null ? new Class<?>[] {} : new Class<?>[] {VALIDATOR_HTTP_CLASS};
   }
 
   @Override
   public void apply(BeanScopeBuilder builder) {
+    if (VALIDATOR_HTTP_CLASS == null) {
+      return;
+    }
 
     builder.provideDefault(
         null,
-        Validator.class,
+        VALIDATOR_HTTP_CLASS,
         () -> {
           final var props = builder.propertyPlugin();
 


### PR DESCRIPTION
Fixes error where using avaje inject and validator without avaje-http-api results in a `java.lang.NoClassDefFoundError: io/avaje/http/api/Validator`