### PR TITLE
Remove Avaje Spi Reliance

### DIFF
--- a/blackbox-test/src/main/resources/META-INF/services/io.avaje.jsonb.JsonbComponent
+++ b/blackbox-test/src/main/resources/META-INF/services/io.avaje.jsonb.JsonbComponent
@@ -1,1 +1,0 @@
-org.example.customer.customtype.CustomTypeComponent

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <inject.version>10.0-RC7</inject.version>
     <http.version>2.0-RC2</http.version>
-    <spi.version>1.11</spi.version>
+    <spi.version>2.0-RC1</spi.version>
   </properties>
 
   <modules>

--- a/validator-generator/pom.xml
+++ b/validator-generator/pom.xml
@@ -13,7 +13,7 @@
   <name>validator generator</name>
   <description>annotation processor generating validation adapters</description>
   <properties>
-    <avaje.prisms.version>1.26</avaje.prisms.version>
+    <avaje.prisms.version>1.27</avaje.prisms.version>
   </properties>
 
   <dependencies>

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ComponentReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ComponentReader.java
@@ -16,18 +16,14 @@ final class ComponentReader {
 
   void read() {
     ProcessingContext.readExistingMetaInfServices().stream()
-        .map(APContext::typeElement)
-        .filter(Objects::nonNull)
-        .filter(
-            t -> "io.avaje.validation.spi.GeneratedComponent".equals(t.getSuperclass().toString()))
-        .findFirst()
-        .ifPresent(
-            moduleType -> {
-              if (moduleType != null) {
-                componentMetaData.setFullName(moduleType.getQualifiedName().toString());
-                readMetaData(moduleType);
-              }
-            });
+      .map(APContext::typeElement)
+      .filter(Objects::nonNull)
+      .filter(t -> "io.avaje.validation.spi.GeneratedComponent".equals(t.getSuperclass().toString()))
+      .findFirst()
+      .ifPresent(moduleType -> {
+        componentMetaData.setFullName(moduleType.getQualifiedName().toString());
+        readMetaData(moduleType);
+      });
   }
 
   /** Read the existing adapters from the MetaData annotation of the generated component. */
@@ -45,8 +41,8 @@ final class ComponentReader {
 
       } else if (metaDataAnnotationFactory != null) {
         metaDataAnnotationFactory.value().stream()
-            .map(APContext::asTypeElement)
-            .forEach(componentMetaData::addAnnotationAdapter);
+          .map(APContext::asTypeElement)
+          .forEach(componentMetaData::addAnnotationAdapter);
       }
     }
   }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ComponentReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ComponentReader.java
@@ -1,25 +1,10 @@
 package io.avaje.validation.generator;
 
-import static io.avaje.validation.generator.APContext.typeElement;
-import static io.avaje.validation.generator.APContext.filer;
-import static io.avaje.validation.generator.APContext.logNote;
-import static io.avaje.validation.generator.APContext.logWarn;
-
-import java.io.FileNotFoundException;
-import java.io.LineNumberReader;
-import java.io.Reader;
-import java.nio.file.NoSuchFileException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 
-import javax.annotation.processing.FilerException;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
-import javax.tools.FileObject;
-import javax.tools.StandardLocation;
 
 final class ComponentReader {
 

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ProcessingContext.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ProcessingContext.java
@@ -90,13 +90,9 @@ final class ProcessingContext {
                 && !moduleInfo.containsOnModulePath("io.avaje.validation.plugin");
 
         if (noHttpPlugin) {
-          logWarn(
-              module,
-              "`requires io.avaje.validation.http` must be explicity added or else avaje-inject may fail to detect the default http validator, validator, and method AOP validator");
+          logWarn(module, "`requires io.avaje.validation.http` must be explicity added or else avaje-inject may fail to detect the default http validator, validator, and method AOP validator");
         } else if (noInjectPlugin) {
-          logWarn(
-              module,
-              "`requires io.avaje.validation.plugin` must be explicity added or else avaje-inject may fail to detect the default validator and method AOP validator");
+          logWarn(module, "`requires io.avaje.validation.plugin` must be explicity added or else avaje-inject may fail to detect the default validator and method AOP validator");
         }
 
       } catch (Exception e) {
@@ -126,15 +122,14 @@ final class ProcessingContext {
   }
 
   static Set<String> readExistingMetaInfServices() {
-    System.out.println("GET GOIT" );
     var services = CTX.get().serviceSet;
     try (final var file =
-            APContext.filer()
-                .getResource(StandardLocation.CLASS_OUTPUT, "", Constants.META_INF_COMPONENT)
-                .toUri()
-                .toURL()
-                .openStream();
-        final var buffer = new BufferedReader(new InputStreamReader(file)); ) {
+           APContext.filer()
+             .getResource(StandardLocation.CLASS_OUTPUT, "", Constants.META_INF_COMPONENT)
+             .toUri()
+             .toURL()
+             .openStream();
+         final var buffer = new BufferedReader(new InputStreamReader(file));) {
 
       String line;
       while ((line = buffer.readLine()) != null) {

--- a/validator-generator/src/main/java/io/avaje/validation/generator/SimpleComponentWriter.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/SimpleComponentWriter.java
@@ -29,7 +29,7 @@ final class SimpleComponentWriter {
       fileObject = createSourceFile(name);
     }
     if (!metaData.isEmpty()) {
-      ProcessingContext.validateModule(name);
+      ProcessingContext.validateModule();
     }
   }
 
@@ -48,10 +48,12 @@ final class SimpleComponentWriter {
   }
 
   void writeMetaInf() throws IOException {
+    var services = ProcessingContext.readExistingMetaInfServices();
     final FileObject fileObject = createMetaInfWriterFor(Constants.META_INF_COMPONENT);
     if (fileObject != null) {
       try (Writer writer = fileObject.openWriter()) {
-        writer.write(metaData.fullName());
+        services.add(metaData.fullName());
+        writer.write(String.join("\n", services));
       }
     }
   }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ValidationProcessor.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ValidationProcessor.java
@@ -332,10 +332,10 @@ public final class ValidationProcessor extends AbstractProcessor {
 
   private void registerSPI(Set<? extends Element> beans) {
     ElementFilter.typesIn(beans).stream()
-        .filter(this::isExtension)
-        .map(TypeElement::getQualifiedName)
-        .map(Object::toString)
-        .forEach(ProcessingContext::addValidatorSpi);
+      .filter(this::isExtension)
+      .map(TypeElement::getQualifiedName)
+      .map(Object::toString)
+      .forEach(ProcessingContext::addValidatorSpi);
   }
 
   private boolean isExtension(TypeElement te) {

--- a/validator-http-plugin/pom.xml
+++ b/validator-http-plugin/pom.xml
@@ -22,13 +22,6 @@
 
     <dependency>
       <groupId>io.avaje</groupId>
-      <artifactId>avaje-spi-service</artifactId>
-      <version>${spi.version}</version>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
-      <groupId>io.avaje</groupId>
       <artifactId>avaje-validator-inject-plugin</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/validator-http-plugin/src/main/java/io/avaje/validation/http/HttpValidatorProvider.java
+++ b/validator-http-plugin/src/main/java/io/avaje/validation/http/HttpValidatorProvider.java
@@ -1,7 +1,6 @@
 package io.avaje.validation.http;
 
 import io.avaje.inject.BeanScopeBuilder;
-import io.avaje.spi.ServiceProvider;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -10,7 +9,6 @@ import java.util.Locale;
 /**
  * Plugin for avaje inject that provides a default Http Validator instance.
  */
-@ServiceProvider
 public final class HttpValidatorProvider implements io.avaje.inject.spi.InjectPlugin {
 
   private static final Class<?> VALIDATOR_HTTP_CLASS = avajeHttpOnClasspath();

--- a/validator-http-plugin/src/main/java/module-info.java
+++ b/validator-http-plugin/src/main/java/module-info.java
@@ -4,7 +4,6 @@ module io.avaje.validation.http {
 
   requires transitive io.avaje.validation.plugin;
   requires transitive io.avaje.http.api;
-  requires static io.avaje.spi;
 
   provides io.avaje.inject.spi.InjectExtension with io.avaje.validation.http.HttpValidatorProvider;
 }

--- a/validator-http-plugin/src/main/resources/META-INF/services/io.avaje.inject.spi.InjectExtension
+++ b/validator-http-plugin/src/main/resources/META-INF/services/io.avaje.inject.spi.InjectExtension
@@ -1,0 +1,1 @@
+io.avaje.validation.http.HttpValidatorProvider

--- a/validator-inject-plugin/pom.xml
+++ b/validator-inject-plugin/pom.xml
@@ -37,13 +37,6 @@
 
     <dependency>
       <groupId>io.avaje</groupId>
-      <artifactId>avaje-spi-service</artifactId>
-      <version>${spi.version}</version>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
-      <groupId>io.avaje</groupId>
       <artifactId>junit</artifactId>
       <version>1.5</version>
       <scope>test</scope>

--- a/validator-inject-plugin/src/main/java/io/avaje/validation/inject/spi/DefaultValidatorProvider.java
+++ b/validator-inject-plugin/src/main/java/io/avaje/validation/inject/spi/DefaultValidatorProvider.java
@@ -11,14 +11,12 @@ import io.avaje.inject.BeanScopeBuilder;
 import io.avaje.inject.aop.AspectProvider;
 import io.avaje.inject.spi.GenericType;
 import io.avaje.inject.spi.InjectPlugin;
-import io.avaje.spi.ServiceProvider;
 import io.avaje.validation.ValidMethod;
 import io.avaje.validation.Validator;
 import io.avaje.validation.adapter.MethodAdapterProvider;
 import io.avaje.validation.inject.aspect.AOPMethodValidator;
 
 /** Plugin for avaje inject that provides a default Validator instance. */
-@ServiceProvider
 public final class DefaultValidatorProvider implements InjectPlugin {
 
   @Override

--- a/validator-inject-plugin/src/main/java/module-info.java
+++ b/validator-inject-plugin/src/main/java/module-info.java
@@ -3,7 +3,6 @@ module io.avaje.validation.plugin {
   requires transitive io.avaje.validation;
   requires transitive io.avaje.inject;
   requires transitive io.avaje.inject.aop;
-  requires static io.avaje.spi;
 
   provides io.avaje.inject.spi.InjectExtension with io.avaje.validation.inject.spi.DefaultValidatorProvider;
 }

--- a/validator-inject-plugin/src/main/resources/META-INF/services/io.avaje.inject.spi.InjectExtension
+++ b/validator-inject-plugin/src/main/resources/META-INF/services/io.avaje.inject.spi.InjectExtension
@@ -1,0 +1,1 @@
+io.avaje.validation.inject.spi.DefaultValidatorProvider


### PR DESCRIPTION
- Uses avaje prisms to validate module-infos
- now annotation processes avaje spi's `ServiceProvider` annotation to register validation extensions