### PR TITLE
Allows `package-private` Classes/Fields/Getters

### DIFF
--- a/validator-generator/src/main/java/io/avaje/validation/generator/AdapterName.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/AdapterName.java
@@ -9,8 +9,9 @@ final class AdapterName {
   final String fullName;
 
   AdapterName(TypeElement origin) {
-    final String originName = origin.getQualifiedName().toString();
-    final String name = origin.getSimpleName().toString();
+
+    String originName = origin.getQualifiedName().toString();
+    String name = origin.getSimpleName().toString();
     String originPackage = ProcessorUtils.packageOf(originName);
     if (origin.getNestingKind().isNested()) {
       final String parent = Util.shortName(originPackage);
@@ -19,7 +20,12 @@ final class AdapterName {
     } else {
       shortName = name;
     }
-    this.adapterPackage = "".equals(originPackage) ? "valid" : originPackage + ".valid";
+    if ("".equals(originPackage)) {
+      this.adapterPackage = "valid";
+    } else {
+      this.adapterPackage =
+          ProcessingContext.isImported(origin) ? originPackage + ".valid" : originPackage;
+    }
     this.fullName = adapterPackage + "." + shortName + "ValidationAdapter";
   }
 

--- a/validator-generator/src/main/java/io/avaje/validation/generator/FieldReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/FieldReader.java
@@ -33,7 +33,7 @@ final class FieldReader {
   FieldReader(Element element, List<String> genericTypeParams, boolean classLevel) {
     this.genericTypeParams = genericTypeParams;
     this.fieldName = element.getSimpleName().toString();
-    this.publicField = element.getModifiers().contains(Modifier.PUBLIC);
+    this.publicField = Util.isPublic(element);
     this.element = element;
     this.elementAnnotations = ElementAnnotationContainer.create(element);
     this.genericType = elementAnnotations.genericType();
@@ -141,7 +141,9 @@ final class FieldReader {
     } else {
       logError(
           element,
-          "Field" + fieldName + " is inaccessible. Add a getter or make the field public.");
+          "Field"
+              + fieldName
+              + " is inaccessible. Add a getter or make the field package-private/public.");
     }
   }
 

--- a/validator-generator/src/main/java/io/avaje/validation/generator/MethodReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/MethodReader.java
@@ -41,7 +41,7 @@ final class MethodReader {
   }
 
   public boolean isPublic() {
-    return element.getModifiers().contains(Modifier.PUBLIC);
+    return Util.isPublic(element);
   }
 
   public boolean isProtected() {

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ProcessingContext.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ProcessingContext.java
@@ -11,15 +11,14 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
 
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.TypeMirror;
+import javax.lang.model.element.Element;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
+
 import io.avaje.validation.generator.ModuleInfoReader.Requires;
 
 final class ProcessingContext {
@@ -31,7 +30,6 @@ final class ProcessingContext {
     private final boolean warnHttp;
     private final boolean injectPresent;
     private final Set<String> serviceSet = new TreeSet<>();
-    private final Set<String> importedTypes = new HashSet<>();
 
     Ctx(ProcessingEnvironment env) {
       var elements = env.getElementUtils();
@@ -62,12 +60,9 @@ final class ProcessingContext {
     return CTX.get().diAnnotation;
   }
 
-  static void addImportedType(TypeMirror mirror) {
-    CTX.get().importedTypes.add(mirror.toString());
-  }
-
-  static boolean isImported(TypeElement type) {
-    return CTX.get().importedTypes.contains(type.asType().toString());
+  static boolean isImported(Element element) {
+    var moduleName = APContext.getProjectModuleElement().getQualifiedName();
+    return !APContext.elements().getModuleOf(element).getQualifiedName().contentEquals(moduleName);
   }
 
   static void validateModule() {

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ProcessingContext.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ProcessingContext.java
@@ -16,6 +16,8 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 import io.avaje.validation.generator.ModuleInfoReader.Requires;
@@ -29,6 +31,7 @@ final class ProcessingContext {
     private final boolean warnHttp;
     private final boolean injectPresent;
     private final Set<String> serviceSet = new TreeSet<>();
+    private final Set<String> importedTypes = new HashSet<>();
 
     Ctx(ProcessingEnvironment env) {
       var elements = env.getElementUtils();
@@ -57,6 +60,14 @@ final class ProcessingContext {
 
   static String diAnnotation() {
     return CTX.get().diAnnotation;
+  }
+
+  static void addImportedType(TypeMirror mirror) {
+    CTX.get().importedTypes.add(mirror.toString());
+  }
+
+  static boolean isImported(TypeElement type) {
+    return CTX.get().importedTypes.contains(type.asType().toString());
   }
 
   static void validateModule() {

--- a/validator-generator/src/main/java/io/avaje/validation/generator/TypeReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/TypeReader.java
@@ -97,7 +97,7 @@ final class TypeReader {
 
   private void readMethod(Element element, TypeElement type, List<FieldReader> localFields) {
     final ExecutableElement methodElement = (ExecutableElement) element;
-    if (methodElement.getModifiers().contains(Modifier.PUBLIC)) {
+    if (Util.isPublic(methodElement)) {
       final List<? extends VariableElement> parameters = methodElement.getParameters();
       final String methodKey = methodElement.getSimpleName().toString();
       final MethodReader methodReader = new MethodReader(methodElement, type).read();

--- a/validator-generator/src/main/java/io/avaje/validation/generator/Util.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/Util.java
@@ -167,11 +167,6 @@ final class Util {
       isImported = ProcessingContext.isImported((TypeElement) element.getEnclosingElement());
     }
 
-    if (element instanceof VariableElement) {
-
-      return !isImported && !mods.contains(Modifier.FINAL);
-    }
-
     return !isImported;
   }
 }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/Util.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/Util.java
@@ -159,13 +159,7 @@ final class Util {
     if (mods.contains(Modifier.PRIVATE) || mods.contains(Modifier.PROTECTED)) {
       return false;
     }
-    boolean isImported;
-    if (element instanceof TypeElement) {
-
-      isImported = ProcessingContext.isImported((TypeElement) element);
-    } else {
-      isImported = ProcessingContext.isImported((TypeElement) element.getEnclosingElement());
-    }
+    var isImported = ProcessingContext.isImported(element);
 
     return !isImported;
   }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/Util.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/Util.java
@@ -1,29 +1,21 @@
 package io.avaje.validation.generator;
 
+import static io.avaje.validation.generator.APContext.logError;
 import static io.avaje.validation.generator.APContext.typeElement;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 
-import static io.avaje.validation.generator.APContext.logError;
-
 final class Util {
-
-  private static final Pattern WHITE_SPACE_REGEX =
-      Pattern.compile("\\s+(?=([^\"]*\"[^\"]*\")*[^\"]*$)");
-  private static final Pattern COMMA_PATTERN =
-      Pattern.compile(", (?=(?:[^\\\"]*\\\"[^\\\"]*\\\")*[^\\\"]*$)");
 
   static final Pattern mapSplitString = Pattern.compile("\\s[A-Za-z0-9]+,|,");
   static final Set<String> BASIC_TYPES = Set.of("java.lang.String", "java.math.BigDecimal");
@@ -156,5 +148,30 @@ final class Util {
     return BASIC_TYPES.contains(topType)
         || topType.startsWith("java.time.")
         || GenericTypeMap.typeOfRaw(topType) != null;
+  }
+
+  static boolean isPublic(Element element) {
+    var mods = element.getModifiers();
+
+    if (mods.contains(Modifier.PUBLIC)) {
+      return true;
+    }
+    if (mods.contains(Modifier.PRIVATE) || mods.contains(Modifier.PROTECTED)) {
+      return false;
+    }
+    boolean isImported;
+    if (element instanceof TypeElement) {
+
+      isImported = ProcessingContext.isImported((TypeElement) element);
+    } else {
+      isImported = ProcessingContext.isImported((TypeElement) element.getEnclosingElement());
+    }
+
+    if (element instanceof VariableElement) {
+
+      return !isImported && !mods.contains(Modifier.FINAL);
+    }
+
+    return !isImported;
   }
 }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ValidationProcessor.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ValidationProcessor.java
@@ -46,7 +46,6 @@ public final class ValidationProcessor extends AbstractProcessor {
   private final ComponentMetaData metaData = new ComponentMetaData();
   private final List<BeanReader> allReaders = new ArrayList<>();
   private final Set<String> sourceTypes = new HashSet<>();
-  private final Set<String> mixInImports = new HashSet<>();
   private final Set<String> alreadyGenerated = new HashSet<>();
   private SimpleComponentWriter componentWriter;
   private boolean readModuleInfo;
@@ -205,11 +204,8 @@ public final class ValidationProcessor extends AbstractProcessor {
     for (final var importedElement : ElementFilter.typesIn(importedElements)) {
       for (final TypeMirror importType :
           ImportValidPojoPrism.getInstanceOn(importedElement).value()) {
-        // if imported by mixin annotation skip
-        if (mixInImports.contains(importType.toString())) {
-          continue;
-        }
         writeAdapterForType(asTypeElement(importType));
+        ProcessingContext.addImportedType(importType);
       }
     }
   }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ValidationProcessor.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ValidationProcessor.java
@@ -205,7 +205,6 @@ public final class ValidationProcessor extends AbstractProcessor {
       for (final TypeMirror importType :
           ImportValidPojoPrism.getInstanceOn(importedElement).value()) {
         writeAdapterForType(asTypeElement(importType));
-        ProcessingContext.addImportedType(importType);
       }
     }
   }

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/PackagePrivateTestClass.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/PackagePrivateTestClass.java
@@ -1,0 +1,51 @@
+package io.avaje.validation.generator.models.valid;
+
+import java.util.List;
+
+import javax.validation.constraints.Negative;
+import javax.validation.constraints.NotEmpty;
+
+import io.avaje.lang.Nullable;
+import io.avaje.validation.constraints.Pattern;
+import io.avaje.validation.constraints.RegexFlag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Valid
+class PackagePrivateTestClass {
+
+  @NotNull
+  @NotBlank(message = "blankLmao")
+  String alias;
+
+  @Nullable String s;
+
+  int i;
+  @NotNull Integer integer;
+
+  char ch;
+  @NotNull Character chara;
+
+  @NotEmpty List<String> list;
+
+  @Pattern(
+      regexp = "ded",
+      flags = {RegexFlag.CANON_EQ, RegexFlag.CASE_INSENSITIVE})
+  String getS() {
+    return s;
+  }
+
+  @Negative(message = "message")
+  int getI() {
+    return i;
+  }
+
+  List<String> getList() {
+    return list;
+  }
+
+  void setList(List<String> list) {
+    this.list = list;
+  }
+}


### PR DESCRIPTION
- Writes all adapters to the same package unless the type is imported.
- non-final package-private fields can be (de)serialized
- allow package-private getters/getter validation
- allow non-imported package-private classes to have adapters generated