### PR TITLE
Writes a file to signal the generator's presence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 *.factorypath
 validator-generator/.factorypath
 validator-generator/io.avaje.validation.spi.ValidationExtension
+validator-generator/avaje-processors.txt

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <inject.version>10.0-RC9</inject.version>
     <http.version>2.0-RC2</http.version>
-    <spi.version>2.0</spi.version>
+    <spi.version>2.1</spi.version>
   </properties>
 
   <modules>

--- a/validator-generator/pom.xml
+++ b/validator-generator/pom.xml
@@ -13,7 +13,7 @@
   <name>validator generator</name>
   <description>annotation processor generating validation adapters</description>
   <properties>
-    <avaje.prisms.version>1.27</avaje.prisms.version>
+    <avaje.prisms.version>1.28</avaje.prisms.version>
   </properties>
 
   <dependencies>

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ProcessingContext.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ProcessingContext.java
@@ -19,7 +19,6 @@ import javax.lang.model.element.Element;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 
-import io.avaje.jsonb.generator.APContext;
 import io.avaje.validation.generator.ModuleInfoReader.Requires;
 
 final class ProcessingContext {

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ProcessingContext.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ProcessingContext.java
@@ -19,6 +19,7 @@ import javax.lang.model.element.Element;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 
+import io.avaje.jsonb.generator.APContext;
 import io.avaje.validation.generator.ModuleInfoReader.Requires;
 
 final class ProcessingContext {
@@ -108,21 +109,9 @@ final class ProcessingContext {
   }
 
   private static boolean buildPluginAvailable() {
-    return resource("target/avaje-plugin-exists.txt", "/target/classes")
-        || resource("build/avaje-plugin-exists.txt", "/build/classes/java/main");
-  }
-
-  private static boolean resource(String relativeName, String replace) {
-    try (var inputStream =
-           new URI(filer().getResource(StandardLocation.CLASS_OUTPUT, "", relativeName)
-             .toUri()
-             .toString()
-             .replace(replace, ""))
-             .toURL()
-             .openStream()) {
-
-      return inputStream.available() > 0;
-    } catch (IOException | URISyntaxException e) {
+    try {
+      return APContext.getBuildResource("avaje-plugin-exists.txt").toFile().exists();
+    } catch (final Exception e) {
       return false;
     }
   }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ValidationProcessor.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ValidationProcessor.java
@@ -1,12 +1,20 @@
 package io.avaje.validation.generator;
 
+import static java.util.stream.Collectors.joining;
+
 import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Stream;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -61,6 +69,25 @@ public final class ValidationProcessor extends AbstractProcessor {
     super.init(processingEnv);
     ProcessingContext.init(processingEnv);
     this.componentWriter = new SimpleComponentWriter(metaData);
+
+    try {
+
+      var file = APContext.getBuildResource("avaje-processors.txt");
+      var addition = new StringBuilder();
+      if (file.toFile().exists()) {
+        var result =
+            Stream.concat(Files.lines(file), Stream.of("avaje-validator-generator"))
+                .distinct()
+                .collect(joining("\n"));
+        addition.append(result);
+      } else {
+        addition.append("avaje-validator-generator");
+      }
+      Files.writeString(file, addition, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+
+    } catch (IOException e) {
+      // not an issue worth failing over
+    }
   }
 
   /** Read the existing metadata from the generated component (if exists). */


### PR DESCRIPTION
Currently, the only way for annotation processors to directly communicate with each other and maven plugins is by writing files and reading them.

Using `Elements` or `Class.forName` to detect other running processors is also unreliable.

This PR enhances the generator to write a marker in `target/avaje-processors.txt` that other processors and tools can pick up.

relies on https://github.com/avaje/avaje-prisms/pull/69