### PR TITLE
Use Jspecify for `@Nullable`

### DIFF
--- a/blackbox-test/src/main/java/example/avaje/mixin/CaptainMixin.java
+++ b/blackbox-test/src/main/java/example/avaje/mixin/CaptainMixin.java
@@ -1,7 +1,8 @@
 package example.avaje.mixin;
 
+import org.jspecify.annotations.Nullable;
+
 import example.avaje.mixin.Captain.Bankai;
-import io.avaje.lang.Nullable;
 import io.avaje.validation.MixIn;
 import io.avaje.validation.constraints.NotBlank;
 import io.avaje.validation.constraints.Positive;

--- a/validator-generator/pom.xml
+++ b/validator-generator/pom.xml
@@ -13,7 +13,7 @@
   <name>validator generator</name>
   <description>annotation processor generating validation adapters</description>
   <properties>
-    <avaje.prisms.version>1.28</avaje.prisms.version>
+    <avaje.prisms.version>1.29</avaje.prisms.version>
   </properties>
 
   <dependencies>

--- a/validator-generator/src/main/java/io/avaje/validation/generator/Util.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/Util.java
@@ -2,9 +2,11 @@ package io.avaje.validation.generator;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
+
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -14,6 +16,7 @@ import static io.avaje.validation.generator.APContext.typeElement;
 
 final class Util {
 
+  private static final String NULLABLE = "Nullable";
   static final Set<String> BASIC_TYPES = Set.of("java.lang.String", "java.math.BigDecimal");
 
   private Util() {}
@@ -24,15 +27,24 @@ final class Util {
       || JakartaValidPrism.isPresent(e);
   }
 
-  /**
-   * Return true if the element has a Nullable annotation.
-   */
+  /** Return true if the element has a Nullable annotation. */
   public static boolean isNullable(Element p) {
-    for (final AnnotationMirror mirror : p.getAnnotationMirrors()) {
-      if ("Nullable".equalsIgnoreCase(shortName(mirror.getAnnotationType().toString()))) {
+
+    if (ProcessorUtils.hasAnnotationWithName(p, NULLABLE)) {
+      return true;
+    }
+
+    var type =
+        p instanceof ExecutableElement ex
+            ? UType.parse(ex.getReturnType())
+            : UType.parse(p.asType());
+
+    for (final AnnotationMirror mirror : type.annotations()) {
+      if (NULLABLE.equalsIgnoreCase(shortName(mirror.getAnnotationType().toString()))) {
         return true;
       }
     }
+
     return false;
   }
 

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/Customer.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/Customer.java
@@ -4,7 +4,8 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.avaje.lang.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import io.avaje.validation.constraints.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/PackagePrivateTestClass.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/PackagePrivateTestClass.java
@@ -5,7 +5,8 @@ import java.util.List;
 import javax.validation.constraints.Negative;
 import javax.validation.constraints.NotEmpty;
 
-import io.avaje.lang.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import io.avaje.validation.constraints.Pattern;
 import io.avaje.validation.constraints.RegexFlag;
 import jakarta.validation.Valid;

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/TestClass.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/TestClass.java
@@ -5,9 +5,10 @@ import java.util.List;
 import javax.validation.constraints.Negative;
 import javax.validation.constraints.NotEmpty;
 
-import io.avaje.lang.Nullable;
-import io.avaje.validation.constraints.RegexFlag;
+import org.jspecify.annotations.Nullable;
+
 import io.avaje.validation.constraints.Pattern;
+import io.avaje.validation.constraints.RegexFlag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -15,9 +15,9 @@
   <dependencies>
 
     <dependency>
-      <groupId>io.avaje</groupId>
-      <artifactId>avaje-lang</artifactId>
-      <version>1.1</version>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <version>1.0.0</version>
     </dependency>
 
     <dependency>

--- a/validator/src/main/java/io/avaje/validation/MixIn.java
+++ b/validator/src/main/java/io/avaje/validation/MixIn.java
@@ -1,7 +1,6 @@
 package io.avaje.validation;
 
 import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.CLASS;
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 import java.lang.annotation.Retention;

--- a/validator/src/main/java/io/avaje/validation/Validator.java
+++ b/validator/src/main/java/io/avaje/validation/Validator.java
@@ -9,7 +9,8 @@ import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import io.avaje.lang.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidationContext;
 import io.avaje.validation.adapter.ValidationContext.AdapterCreateRequest;

--- a/validator/src/main/java/io/avaje/validation/adapter/ValidationContext.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/ValidationContext.java
@@ -7,7 +7,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import io.avaje.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /** Context used to lookup validation adapters and create validation requests. */
 public interface ValidationContext {

--- a/validator/src/main/java/module-info.java
+++ b/validator/src/main/java/module-info.java
@@ -5,11 +5,11 @@ module io.avaje.validation {
   exports io.avaje.validation.groups;
   exports io.avaje.validation.spi;
 
-  requires io.avaje.lang;
   requires io.avaje.applog;
   requires static io.avaje.inject;
   requires static io.avaje.inject.aop;
   requires static io.avaje.spi;
+  requires static transitive org.jspecify;
 
   uses io.avaje.validation.spi.ValidationExtension;
 }


### PR DESCRIPTION
- replaces avaje-lang with jspecify
- now can read `TYPE_USE` nullable annotations


Refer to https://jspecify.dev/docs/using#if-your-code-already-uses-jsr-305-annotations for differences we might see with this change

Also refer to https://jspecify.dev/docs/tool-conformance ... for more details on tooling support