### PR TITLE
Add non-null constraints when in a Jspecify `@NullMarked` module/package

### DIFF
--- a/blackbox-test/src/main/java/module-info.java
+++ b/blackbox-test/src/main/java/module-info.java
@@ -6,6 +6,8 @@ module blackbox.test {
   requires io.avaje.validation.contraints;
   requires jakarta.validation;
   requires jakarta.inject;
+  requires org.jspecify;
+
   provides io.avaje.validation.spi.ValidationExtension with example.avaje.valid.GeneratedValidatorComponent;
   provides io.avaje.inject.spi.InjectExtension with example.avaje.GeneratedModule;
 }

--- a/blackbox-test/src/test/java/example/avaje/jspecify/JSpecifyNotNull.java
+++ b/blackbox-test/src/test/java/example/avaje/jspecify/JSpecifyNotNull.java
@@ -2,9 +2,7 @@ package example.avaje.jspecify;
 
 import org.jspecify.annotations.Nullable;
 
-import io.avaje.validation.constraints.NotBlank;
 import jakarta.validation.Valid;
 
 @Valid
-public record JSpecifyNotNull(
-    @NotBlank String basic, @NotBlank String withMax, @Nullable @NotBlank String withCustom) {}
+public record JSpecifyNotNull(String basic, String withMax, @Nullable String withCustom) {}

--- a/blackbox-test/src/test/java/example/avaje/jspecify/JSpecifyNotNull.java
+++ b/blackbox-test/src/test/java/example/avaje/jspecify/JSpecifyNotNull.java
@@ -1,0 +1,10 @@
+package example.avaje.jspecify;
+
+import org.jspecify.annotations.Nullable;
+
+import io.avaje.validation.constraints.NotBlank;
+import jakarta.validation.Valid;
+
+@Valid
+public record JSpecifyNotNull(
+    @NotBlank String basic, @NotBlank String withMax, @Nullable @NotBlank String withCustom) {}

--- a/blackbox-test/src/test/java/example/avaje/jspecify/JSpecifyNullUnmarked.java
+++ b/blackbox-test/src/test/java/example/avaje/jspecify/JSpecifyNullUnmarked.java
@@ -1,0 +1,10 @@
+package example.avaje.jspecify;
+
+import org.jspecify.annotations.NullUnmarked;
+
+import io.avaje.validation.constraints.Null;
+import jakarta.validation.Valid;
+
+@Valid
+@NullUnmarked
+public record JSpecifyNullUnmarked(@Null String basic) {}

--- a/blackbox-test/src/test/java/example/avaje/jspecify/JSpecifyTest.java
+++ b/blackbox-test/src/test/java/example/avaje/jspecify/JSpecifyTest.java
@@ -1,7 +1,6 @@
 package example.avaje.jspecify;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Locale;
 

--- a/blackbox-test/src/test/java/example/avaje/jspecify/JSpecifyTest.java
+++ b/blackbox-test/src/test/java/example/avaje/jspecify/JSpecifyTest.java
@@ -1,0 +1,38 @@
+package example.avaje.jspecify;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.ConstraintViolationException;
+import io.avaje.validation.Validator;
+
+public class JSpecifyTest {
+
+  final Validator validator =
+      Validator.builder()
+          .add(JSpecifyNotNull.class, JSpecifyNotNullValidationAdapter::new)
+          .add(JSpecifyNullUnmarked.class, JSpecifyNullUnmarkedValidationAdapter::new)
+          .addLocales(Locale.GERMAN)
+          .build();
+
+  @Test
+  void valid() {
+    var value = new JSpecifyNotNull("ok", "ok", "ok");
+    validator.validate(value);
+    validator.validate(new JSpecifyNullUnmarked(null));
+  }
+
+  @Test
+  void inValidNull() {
+    var value = new JSpecifyNotNull(null, null, null);
+    try {
+      validator.validate(value);
+    } catch (ConstraintViolationException e) {
+      assertThat(e.violations()).hasSize(2);
+    }
+  }
+}

--- a/blackbox-test/src/test/java/example/avaje/jspecify/package-info.java
+++ b/blackbox-test/src/test/java/example/avaje/jspecify/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package example.avaje.jspecify;

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
@@ -77,7 +77,6 @@ public record ElementAnnotationContainer(
 
     if (Util.isNonNullable(element)) {
       var nonNull = UType.parse(APContext.typeElement(NonNullPrism.PRISM_TYPE).asType());
-
       annotations.put(nonNull, "Map.of(\"message\",\"{avaje.NotNull.message}\")");
     }
 
@@ -129,7 +128,6 @@ public record ElementAnnotationContainer(
 
     if (Util.isNonNullable(varElement)) {
       var nonNull = UType.parse(APContext.typeElement(NonNullPrism.PRISM_TYPE).asType());
-
       annotations.put(nonNull, "Map.of(\"message\",\"{avaje.NotNull.message}\")");
     }
 

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
@@ -26,7 +26,6 @@ public record ElementAnnotationContainer(
 
   static ElementAnnotationContainer create(Element element) {
     final var hasValid = ValidPrism.isPresent(element);
-
     Map<UType, String> typeUse1;
     Map<UType, String> typeUse2;
     final Map<UType, String> crossParam = new HashMap<>();
@@ -76,6 +75,12 @@ public record ElementAnnotationContainer(
                     a -> UType.parse(a.getAnnotationType()),
                     a -> AnnotationUtil.annotationAttributeMap(a, element)));
 
+    if (Util.isNonNullable(element)) {
+      var nonNull = UType.parse(APContext.typeElement(NonNullPrism.PRISM_TYPE).asType());
+
+      annotations.put(nonNull, "Map.of(\"message\",\"{avaje.NotNull.message}\")");
+    }
+
     return new ElementAnnotationContainer(
         uType, hasValid, annotations, typeUse1, typeUse2, crossParam);
   }
@@ -89,7 +94,7 @@ public record ElementAnnotationContainer(
     return ConstraintPrism.isPresent(element);
   }
 
-  // it seems we cannot directly retrieve mirrors from var elements, for varElements needs special
+  // it seems we cannot directly retrieve mirrors from var elements, so var Elements needs special
   // handling
 
   static ElementAnnotationContainer create(VariableElement varElement) {
@@ -121,6 +126,12 @@ public record ElementAnnotationContainer(
                     a -> AnnotationUtil.annotationAttributeMap(a, varElement)));
 
     final boolean hasValid = uType.annotations().stream().anyMatch(ValidPrism::isInstance);
+
+    if (Util.isNonNullable(varElement)) {
+      var nonNull = UType.parse(APContext.typeElement(NonNullPrism.PRISM_TYPE).asType());
+
+      annotations.put(nonNull, "Map.of(\"message\",\"{avaje.NotNull.message}\")");
+    }
 
     return new ElementAnnotationContainer(
         uType, hasValid, annotations, typeUse1, typeUse2, Map.of());

--- a/validator-generator/src/main/java/io/avaje/validation/generator/TypeReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/TypeReader.java
@@ -129,7 +129,9 @@ final class TypeReader {
 
   private boolean includeField(Element element) {
     return !element.getModifiers().contains(Modifier.TRANSIENT)
-        && (!element.getAnnotationMirrors().isEmpty() || element.asType().toString().contains("@"));
+        && (!element.getAnnotationMirrors().isEmpty()
+            || element.asType().toString().contains("@")
+            || Util.isNonNullable(element));
   }
 
   private void readMethod(Element element, TypeElement type, List<FieldReader> localFields) {

--- a/validator-generator/src/main/java/io/avaje/validation/generator/TypeReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/TypeReader.java
@@ -107,7 +107,7 @@ final class TypeReader {
       element = mixInField;
     }
 
-    if (includeField(element)) {
+    if (includeField(element) || Util.isNonNullable(element)) {
       seenFields.add(element.toString());
       var reader = new FieldReader(element, genericTypeParams);
       if (reader.hasConstraints() || ValidPrism.isPresent(element)) {
@@ -129,9 +129,7 @@ final class TypeReader {
 
   private boolean includeField(Element element) {
     return !element.getModifiers().contains(Modifier.TRANSIENT)
-        && (!element.getAnnotationMirrors().isEmpty()
-            || element.asType().toString().contains("@")
-            || Util.isNonNullable(element));
+        && (!element.getAnnotationMirrors().isEmpty() || element.asType().toString().contains("@"));
   }
 
   private void readMethod(Element element, TypeElement type, List<FieldReader> localFields) {

--- a/validator-generator/src/main/java/io/avaje/validation/generator/Util.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/Util.java
@@ -168,4 +168,32 @@ final class Util {
     return "";
   }
 
+  public static boolean isNonNullable(Element e) {
+    UType uType;
+    if (e instanceof final ExecutableElement executableElement) {
+      uType = UType.parse(executableElement.getReturnType());
+
+    } else {
+      uType = UType.parse(e.asType());
+    }
+
+    for (var mirror : uType.annotations()) {
+      if (mirror.getAnnotationType().toString().endsWith("Nullable")) {
+        return false;
+      } else if (NonNullPrism.isInstance(mirror)) {
+        return true;
+      }
+    }
+
+    return checkNullMarked(e);
+  }
+
+  private static boolean checkNullMarked(Element e) {
+    if (e == null || NullUnmarkedPrism.isPresent(e)) {
+      return false;
+    } else if (NullMarkedPrism.isPresent(e)) {
+      return true;
+    }
+    return checkNullMarked(e.getEnclosingElement());
+  }
 }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/Util.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/Util.java
@@ -168,15 +168,13 @@ final class Util {
     return "";
   }
 
-  public static boolean isNonNullable(Element e) {
+  static boolean isNonNullable(Element e) {
     UType uType;
     if (e instanceof final ExecutableElement executableElement) {
       uType = UType.parse(executableElement.getReturnType());
-
     } else {
       uType = UType.parse(e.asType());
     }
-
     for (var mirror : uType.annotations()) {
       if (mirror.getAnnotationType().toString().endsWith("Nullable")) {
         return false;
@@ -184,7 +182,6 @@ final class Util {
         return true;
       }
     }
-
     return checkNullMarked(e);
   }
 

--- a/validator-generator/src/main/java/io/avaje/validation/generator/package-info.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/package-info.java
@@ -1,10 +1,13 @@
-@GeneratePrism(io.avaje.validation.ImportValidPojo.class)
 @GeneratePrism(io.avaje.validation.adapter.ConstraintAdapter.class)
+@GeneratePrism(io.avaje.validation.ImportValidPojo.class)
 @GeneratePrism(io.avaje.validation.spi.MetaData.class)
 @GeneratePrism(io.avaje.validation.spi.MetaData.Factory.class)
 @GeneratePrism(io.avaje.validation.spi.MetaData.AnnotationFactory.class)
-@GeneratePrism(io.avaje.validation.ValidMethod.class)
 @GeneratePrism(io.avaje.validation.MixIn.class)
+@GeneratePrism(org.jspecify.annotations.NullMarked.class)
+@GeneratePrism(org.jspecify.annotations.NullUnmarked.class)
+@GeneratePrism(org.jspecify.annotations.NonNull.class)
+@GeneratePrism(io.avaje.validation.ValidMethod.class)
 package io.avaje.validation.generator;
 
 import io.avaje.prism.GeneratePrism;

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/JSpecifyNotNull.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/JSpecifyNotNull.java
@@ -3,10 +3,8 @@ package io.avaje.validation.generator.models.valid;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-import io.avaje.validation.constraints.NotBlank;
 import jakarta.validation.Valid;
 
 @Valid
 @NullMarked
-public record JSpecifyNotNull(
-    @NotBlank String basic, @NotBlank String withMax, @Nullable @NotBlank String withCustom) {}
+public record JSpecifyNotNull(String basic, String withMax, @Nullable String withCustom) {}

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/JSpecifyNotNull.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/JSpecifyNotNull.java
@@ -1,0 +1,12 @@
+package io.avaje.validation.generator.models.valid;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import io.avaje.validation.constraints.NotBlank;
+import jakarta.validation.Valid;
+
+@Valid
+@NullMarked
+public record JSpecifyNotNull(
+    @NotBlank String basic, @NotBlank String withMax, @Nullable @NotBlank String withCustom) {}

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/JSpecifyNullUnmarked.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/JSpecifyNullUnmarked.java
@@ -1,0 +1,9 @@
+package io.avaje.validation.generator.models.valid;
+
+import org.jspecify.annotations.NullUnmarked;
+
+import jakarta.validation.Valid;
+
+@Valid
+@NullUnmarked
+public record JSpecifyNullUnmarked(String basic, String withMax, String withCustom) {}


### PR DESCRIPTION
- When a Validation class is in a `@NullMarked` module/package/type, all field constraints are augmented with a non-null check unless `@Nullable` is specified

Given a class like:

```java 

@Valid
@NullMarked
public record JSpecifyNotNull(String basic, String withMax, @Nullable String withCustom) {}
```

the following is generated:


```java
@Generated("avaje-validator-generator")
public final class JSpecifyNotNullValidationAdapter implements ValidationAdapter<JSpecifyNotNull> {

  private final ValidationAdapter<String> basicValidationAdapter;
  private final ValidationAdapter<String> withMaxValidationAdapter;
  private final ValidationAdapter<JSpecifyNotNull> jspecifyNotNullValidationAdapter;

  public JSpecifyNotNullValidationAdapter(ValidationContext ctx) {
    this.basicValidationAdapter = 
        ctx.<String>adapter(NonNull.class, Map.of("message","{avaje.NotNull.message}"));

    this.withMaxValidationAdapter = 
        ctx.<String>adapter(NonNull.class, Map.of("message","{avaje.NotNull.message}"));

    this.jspecifyNotNullValidationAdapter = 
        ctx.<JSpecifyNotNull>adapter(NonNull.class, Map.of("message","{avaje.NotNull.message}"));

  }

  @Override
  public boolean validate(JSpecifyNotNull value, ValidationRequest request, String field) {
    if (field != null) {
      request.pushPath(field);
    }
    var _$basic = value.basic();
    basicValidationAdapter.validate(_$basic, request, "basic");

    var _$withMax = value.withMax();
    withMaxValidationAdapter.validate(_$withMax, request, "withMax");

    if (!request.hasViolations()) {
      jspecifyNotNullValidationAdapter.validate(value, request, field);
    }


    if (field != null) {
      request.popPath();
    }
    return true;
  }
}