### PR TITLE
Fix Repeatable Annotation Name Collision

### DIFF
--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/DateRange.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/DateRange.java
@@ -61,7 +61,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Constraint(unboxPrimitives = true)
 @Documented
 @Retention(RUNTIME)
-@Repeatable(DateRange.List.class)
+@Repeatable(DateRange.DateRanges.class)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
 public @interface DateRange {
 
@@ -79,7 +79,7 @@ public @interface DateRange {
   @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
   @Retention(RUNTIME)
   @Documented
-  @interface List {
+  @interface DateRanges {
     DateRange[] value();
   }
 }

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/DecimalMax.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/DecimalMax.java
@@ -11,8 +11,6 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import io.avaje.validation.constraints.DecimalMax.List;
-
 /**
  * The annotated element must be a number whose value must be lower or equal to the specified
  * maximum.
@@ -36,7 +34,7 @@ import io.avaje.validation.constraints.DecimalMax.List;
 @Constraint
 @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
 @Retention(RUNTIME)
-@Repeatable(List.class)
+@Repeatable(DecimalMax.DecimalMaxs.class)
 public @interface DecimalMax {
 
   String message() default "{avaje.DecimalMax.message}";
@@ -67,7 +65,7 @@ public @interface DecimalMax {
    */
   @Target({METHOD, FIELD})
   @Retention(RUNTIME)
-  @interface List {
+  @interface DecimalMaxs {
 
     DecimalMax[] value();
   }

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/DecimalMin.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/DecimalMin.java
@@ -17,8 +17,6 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import io.avaje.validation.constraints.DecimalMin.List;
-
 /**
  * The annotated element must be a number whose value must be higher or equal to the specified
  * minimum.
@@ -42,7 +40,7 @@ import io.avaje.validation.constraints.DecimalMin.List;
 @Constraint
 @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
 @Retention(RUNTIME)
-@Repeatable(List.class)
+@Repeatable(DecimalMin.DecimalMins.class)
 public @interface DecimalMin {
 
   String message() default "{avaje.DecimalMin.message}";
@@ -73,7 +71,7 @@ public @interface DecimalMin {
    */
   @Target({METHOD, FIELD})
   @Retention(RUNTIME)
-  @interface List {
+  @interface DecimalMins {
 
     DecimalMin[] value();
   }

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Digits.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Digits.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
 @Constraint
 @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
-@Repeatable(Digits.List.class)
+@Repeatable(Digits.Digitses.class)
 public @interface Digits {
   String message() default "{avaje.Digits.message}";
 
@@ -45,7 +45,7 @@ public @interface Digits {
   @Target({ElementType.METHOD, ElementType.FIELD})
   @Retention(RetentionPolicy.RUNTIME)
   @Documented
-  public @interface List {
+  public @interface Digitses {
     Digits[] value();
   }
 }

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Length.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Length.java
@@ -16,7 +16,7 @@ import static java.lang.annotation.ElementType.*;
 @Constraint
 @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
-@Repeatable(Length.List.class)
+@Repeatable(Length.Lengths.class)
 public @interface Length {
 
   String message() default "{avaje.Length.message}";
@@ -30,7 +30,7 @@ public @interface Length {
   @Target({ElementType.METHOD, ElementType.FIELD})
   @Retention(RetentionPolicy.RUNTIME)
   @Documented
-  @interface List {
+  @interface Lengths {
     Length[] value();
   }
 }

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Max.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Max.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
 @Constraint(unboxPrimitives = true)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
-@Repeatable(Max.List.class)
+@Repeatable(Max.Maxs.class)
 public @interface Max {
   String message() default "{avaje.Max.message}";
 
@@ -46,7 +46,7 @@ public @interface Max {
   @Target({ElementType.METHOD, ElementType.FIELD})
   @Retention(RetentionPolicy.RUNTIME)
   @Documented
-  @interface List {
+  @interface Maxs {
     Max[] value();
   }
 }

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Min.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Min.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
 @Constraint(unboxPrimitives = true)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
-@Repeatable(Min.List.class)
+@Repeatable(Min.Mins.class)
 public @interface Min {
   String message() default "{avaje.Min.message}";
 
@@ -46,7 +46,7 @@ public @interface Min {
   @Target({ElementType.METHOD, ElementType.FIELD})
   @Retention(RetentionPolicy.RUNTIME)
   @Documented
-  @interface List {
+  @interface Mins {
     Min[] value();
   }
 }

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Pattern.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Pattern.java
@@ -12,8 +12,6 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import io.avaje.validation.constraints.Pattern.List;
-
 /**
  * The annotated {@code CharSequence} must match the specified regular expression. The regular
  * expression follows the Java regular expression conventions see {@link java.util.regex.Pattern}.
@@ -25,7 +23,7 @@ import io.avaje.validation.constraints.Pattern.List;
 @Constraint
 @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
 @Retention(RUNTIME)
-@Repeatable(List.class)
+@Repeatable(Pattern.Patterns.class)
 @Documented
 public @interface Pattern {
 
@@ -49,7 +47,7 @@ public @interface Pattern {
   @Target({METHOD, FIELD})
   @Retention(RUNTIME)
   @Documented
-  @interface List {
+  @interface Patterns {
 
     Pattern[] value();
   }

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Positive.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Positive.java
@@ -12,8 +12,6 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import io.avaje.validation.constraints.Positive.List;
-
 /**
  * The annotated element must be a strictly positive number (i.e. 0 is considered as an invalid
  * value).
@@ -34,7 +32,6 @@ import io.avaje.validation.constraints.Positive.List;
 @Constraint(unboxPrimitives = true)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
 @Retention(RUNTIME)
-@Repeatable(List.class)
 @Documented
 public @interface Positive {
 
@@ -42,16 +39,4 @@ public @interface Positive {
 
   Class<?>[] groups() default {};
 
-  /**
-   * Defines several {@link Positive} constraints on the same element.
-   *
-   * @see Positive
-   */
-  @Target({METHOD, FIELD})
-  @Retention(RUNTIME)
-  @Documented
-  @interface List {
-
-    Positive[] value();
-  }
 }

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Range.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Range.java
@@ -13,8 +13,6 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import io.avaje.validation.constraints.Range.List;
-
 /**
  * The annotated element has to be in the appropriate range. Apply on numeric values or string
  * representation of the numeric value.
@@ -24,7 +22,7 @@ import io.avaje.validation.constraints.Range.List;
 @Constraint(unboxPrimitives = true)
 @Documented
 @Retention(RUNTIME)
-@Repeatable(List.class)
+@Repeatable(Range.Ranges.class)
 @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
 public @interface Range {
   long min() default 0;
@@ -39,7 +37,7 @@ public @interface Range {
   @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
   @Retention(RUNTIME)
   @Documented
-  public @interface List {
+  public @interface Ranges {
     Range[] value();
   }
 }

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Size.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Size.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
 @Constraint
 @Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
-@Repeatable(Size.List.class)
+@Repeatable(Size.Sizes.class)
 public @interface Size {
   String message() default "{avaje.Size.message}";
 
@@ -45,7 +45,7 @@ public @interface Size {
   @Target({ElementType.METHOD, ElementType.FIELD})
   @Retention(RetentionPolicy.RUNTIME)
   @Documented
-  @interface List {
+  @interface Sizes {
     Size[] value();
   }
 }

--- a/validator/src/main/java/io/avaje/validation/CrossParamConstraint.java
+++ b/validator/src/main/java/io/avaje/validation/CrossParamConstraint.java
@@ -7,9 +7,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * Marks an method annotation as a CrossParamConstraint used for validating multiple method
+ * Marks a method annotation as a CrossParamConstraint used for validating multiple method
  * parameters
  */
 @Retention(CLASS)
-@Target({ANNOTATION_TYPE})
+@Target(ANNOTATION_TYPE)
 public @interface CrossParamConstraint {}


### PR DESCRIPTION
`List` as the repeatable annotation name conflicts with `java.util.List` when using module imports