### PR TITLE
Fix "continue validation" (list of Pattern validation etc)

### DIFF
--- a/blackbox-test/src/test/java/example/avaje/repeat/PatternListTest.java
+++ b/blackbox-test/src/test/java/example/avaje/repeat/PatternListTest.java
@@ -1,0 +1,54 @@
+package example.avaje.repeat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.ConstraintViolation;
+import io.avaje.validation.ConstraintViolationException;
+import io.avaje.validation.Validator;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+
+public class PatternListTest {
+
+  @Valid
+  public static class Bean {
+
+    @Pattern(regexp = "^[ABCD]{4}$", message = "Missing ABCD")
+    @Pattern(regexp = ".*[A].*", message = "Missing A")
+    @Pattern(regexp = ".*[B].*", message = "Missing B")
+    @Pattern(regexp = ".*[C].*", message = "Missing C")
+    @Pattern(regexp = ".*[D].*", message = "Missing D")
+    public String field;
+  }
+
+  private final Validator validator =
+    Validator.builder()
+      .build();
+
+  @Test
+  void testNoViolations() {
+    final Bean bean = new Bean();
+    bean.field = "ABCD";
+
+    validator.validate(bean);
+    // no exception
+  }
+
+  @Test
+  void testMultipleViolations() {
+    final Bean bean = new Bean();
+    bean.field = "f";
+
+    final ConstraintViolationException exceptions =
+      assertThrows(ConstraintViolationException.class, () -> validator.validate(bean));
+
+    for (final ConstraintViolation violation : exceptions.violations()) {
+      System.out.println("Violation: " + violation.toString());
+    }
+
+    assertEquals(5, exceptions.violations().size());
+  }
+}

--- a/blackbox-test/src/test/java/example/avaje/repeat/SignupRequestTest.java
+++ b/blackbox-test/src/test/java/example/avaje/repeat/SignupRequestTest.java
@@ -23,10 +23,11 @@ class SignupRequestTest {
     SignupRequest req = new SignupRequest("foo");
 
     var violations = all(req, Locale.ENGLISH);
-    assertThat(violations).hasSize(3);
+    assertThat(violations).hasSize(4);
     assertThat(violations.get(0).message()).isEqualTo("Signup password size error");
     assertThat(violations.get(1).message()).isEqualTo("Signup must have at least 1 upper case");
-    assertThat(violations.get(2).message()).isEqualTo("Signup special character");
+    assertThat(violations.get(2).message()).isEqualTo("Signup digit");
+    assertThat(violations.get(3).message()).isEqualTo("Signup special character");
   }
 
   @Test

--- a/validator/src/main/java/io/avaje/validation/adapter/AbstractConstraintAdapter.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/AbstractConstraintAdapter.java
@@ -32,7 +32,6 @@ public abstract class AbstractConstraintAdapter<T> implements ValidationAdapter<
     }
     if (!isValid(value)) {
       req.addViolation(message, propertyName);
-      return false;
     }
     return true;
   }

--- a/validator/src/main/java/io/avaje/validation/core/adapters/BasicAdapters.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/BasicAdapters.java
@@ -220,7 +220,7 @@ public final class BasicAdapters {
       } else if (value instanceof final Map<?, ?> map) {
         return map.isEmpty();
       } else if (value instanceof final CharSequence sequence) {
-        return sequence.length() == 0;
+        return sequence.isEmpty();
       } else if (value.getClass().isArray()) {
         return arrayLength(value) == 0;
       }
@@ -239,7 +239,7 @@ public final class BasicAdapters {
 
     @Override
     public boolean isValid(Boolean value) {
-      return value == null || assertBool == value.booleanValue();
+      return value == null || assertBool == value;
     }
 
     @Override

--- a/validator/src/main/java/io/avaje/validation/core/adapters/BasicAdapters.java
+++ b/validator/src/main/java/io/avaje/validation/core/adapters/BasicAdapters.java
@@ -110,7 +110,6 @@ public final class BasicAdapters {
         final var len = sequence.length();
         if (len > max || len < min) {
           req.addViolation(message, propertyName);
-          return false;
         }
       } else if (value instanceof final Collection<?> col) {
         final var len = col.size();
@@ -173,7 +172,6 @@ public final class BasicAdapters {
       }
       if (maxLength > 0 && value.length() > maxLength) {
         req.addViolation(maxLengthMessage != null ? maxLengthMessage : message, propertyName);
-        return false;
       }
       return true;
     }

--- a/validator/src/test/java/io/avaje/validation/core/BasicTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/BasicTest.java
@@ -3,6 +3,7 @@ package io.avaje.validation.core;
 import io.avaje.validation.ConstraintViolation;
 import io.avaje.validation.ConstraintViolationException;
 import io.avaje.validation.Validator;
+import io.avaje.validation.adapter.ValidationAdapter;
 import io.avaje.validation.adapter.ValidationContext;
 
 import java.time.Duration;
@@ -39,5 +40,11 @@ public abstract class BasicTest {
       assertThat(violations).hasSize(1);
       return violations.get(0);
     }
+  }
+
+  protected boolean isValid(ValidationAdapter<Object> adapter, Object obj) {
+    var req = new DRequest((DValidator) validator, false, null, List.of());
+    adapter.validate(obj, req);
+    return !req.hasViolations();
   }
 }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/AssertBooleanTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/AssertBooleanTest.java
@@ -32,19 +32,19 @@ class AssertBooleanTest extends BasicTest {
 
   @Test
   void testNull() {
-    assertThat(trueAdapter.validate(null, request)).isTrue();
-    assertThat(falseAdapter.validate(null, request)).isTrue();
+    assertThat(isValid(trueAdapter, null)).isTrue();
+    assertThat(isValid(falseAdapter, null)).isTrue();
   }
 
   @Test
   void testTrue() {
-    assertThat(trueAdapter.validate(true, request)).isTrue();
-    assertThat(falseAdapter.validate(true, request)).isFalse();
+    assertThat(isValid(trueAdapter, true)).isTrue();
+    assertThat(isValid(falseAdapter, true)).isFalse();
   }
 
   @Test
   void testFalse() {
-    assertThat(trueAdapter.validate(false, request)).isFalse();
-    assertThat(falseAdapter.validate(false, request)).isTrue();
+    assertThat(isValid(trueAdapter, false)).isFalse();
+    assertThat(isValid(falseAdapter, false)).isTrue();
   }
 }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/AssertBooleanTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/AssertBooleanTest.java
@@ -26,8 +26,8 @@ class AssertBooleanTest extends BasicTest {
   @Test
   void continueOnInvalid_expect_false() {
     // does not matter if it continues or not really
-    assertThat(trueAdapter.validate(false, request, "foo")).isFalse();
-    assertThat(falseAdapter.validate(true, request, "foo")).isFalse();
+    assertThat(trueAdapter.validate(false, request, "foo")).isTrue();
+    assertThat(falseAdapter.validate(true, request, "foo")).isTrue();
   }
 
   @Test

--- a/validator/src/test/java/io/avaje/validation/core/adapters/AssertBooleanTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/AssertBooleanTest.java
@@ -24,6 +24,13 @@ class AssertBooleanTest extends BasicTest {
       ctx.adapter(AssertFalse.class, Map.of("message", "is false"));
 
   @Test
+  void continueOnInvalid_expect_false() {
+    // does not matter if it continues or not really
+    assertThat(trueAdapter.validate(false, request, "foo")).isFalse();
+    assertThat(falseAdapter.validate(true, request, "foo")).isFalse();
+  }
+
+  @Test
   void testNull() {
     assertThat(trueAdapter.validate(null, request)).isTrue();
     assertThat(falseAdapter.validate(null, request)).isTrue();

--- a/validator/src/test/java/io/avaje/validation/core/adapters/DecimalMinMaxTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/DecimalMinMaxTest.java
@@ -24,6 +24,13 @@ class DecimalMinMaxTest extends BasicTest {
       ctx.adapter(DecimalMax.class, Map.of("message", "maxwell", "value", "69", "_type", "Number"));
 
   @Test
+  void continueOnInvalid_expect_false() {
+    //BUG: This should really return true? - should continue validation !!
+    assertThat(minAdapter.validate(BigDecimal.valueOf(-100), request, "foo")).isFalse();
+    assertThat(maxAdapter.validate(BigDecimal.valueOf(100), request, "foo")).isFalse();
+  }
+
+  @Test
   void testNull() {
     assertThat(minAdapter.validate(null, request)).isTrue();
     assertThat(maxAdapter.validate(null, request)).isTrue();

--- a/validator/src/test/java/io/avaje/validation/core/adapters/DecimalMinMaxTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/DecimalMinMaxTest.java
@@ -25,9 +25,8 @@ class DecimalMinMaxTest extends BasicTest {
 
   @Test
   void continueOnInvalid_expect_false() {
-    //BUG: This should really return true? - should continue validation !!
-    assertThat(minAdapter.validate(BigDecimal.valueOf(-100), request, "foo")).isFalse();
-    assertThat(maxAdapter.validate(BigDecimal.valueOf(100), request, "foo")).isFalse();
+    assertThat(minAdapter.validate(BigDecimal.valueOf(-100), request, "foo")).isTrue();
+    assertThat(maxAdapter.validate(BigDecimal.valueOf(100), request, "foo")).isTrue();
   }
 
   @Test

--- a/validator/src/test/java/io/avaje/validation/core/adapters/DecimalMinMaxTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/DecimalMinMaxTest.java
@@ -32,56 +32,56 @@ class DecimalMinMaxTest extends BasicTest {
 
   @Test
   void testNull() {
-    assertThat(minAdapter.validate(null, request)).isTrue();
-    assertThat(maxAdapter.validate(null, request)).isTrue();
+    assertThat(isValid(minAdapter, null)).isTrue();
+    assertThat(isValid(maxAdapter, null)).isTrue();
   }
 
   @Test
   void testMax() {
 
-    assertThat(maxAdapter.validate(0, request)).isTrue();
-    assertThat(maxAdapter.validate(0f, request)).isTrue();
-    assertThat(maxAdapter.validate(0D, request)).isTrue();
-    assertThat(maxAdapter.validate(0L, request)).isTrue();
-    assertThat(maxAdapter.validate((short) 0, request)).isTrue();
-    assertThat(maxAdapter.validate((byte) 0, request)).isTrue();
-    assertThat(maxAdapter.validate(BigInteger.valueOf(0), request)).isTrue();
-    assertThat(maxAdapter.validate(BigDecimal.valueOf(0), request)).isTrue();
+    assertThat(isValid(maxAdapter, 0)).isTrue();
+    assertThat(isValid(maxAdapter, 0f)).isTrue();
+    assertThat(isValid(maxAdapter, 0D)).isTrue();
+    assertThat(isValid(maxAdapter, 0L)).isTrue();
+    assertThat(isValid(maxAdapter, (short) 0)).isTrue();
+    assertThat(isValid(maxAdapter, (byte) 0)).isTrue();
+    assertThat(isValid(maxAdapter, BigInteger.valueOf(0))).isTrue();
+    assertThat(isValid(maxAdapter, BigDecimal.valueOf(0))).isTrue();
   }
 
   @Test
   void testMin() {
-    assertThat(minAdapter.validate(-0, request)).isTrue();
-    assertThat(minAdapter.validate(-0f, request)).isTrue();
-    assertThat(minAdapter.validate(-0D, request)).isTrue();
-    assertThat(minAdapter.validate(-0L, request)).isTrue();
-    assertThat(minAdapter.validate((short) -0, request)).isTrue();
-    assertThat(minAdapter.validate((byte) -0, request)).isTrue();
-    assertThat(minAdapter.validate(BigInteger.valueOf(-0), request)).isTrue();
-    assertThat(minAdapter.validate(BigDecimal.valueOf(-0), request)).isTrue();
+    assertThat(isValid(minAdapter, -0)).isTrue();
+    assertThat(isValid(minAdapter, -0f)).isTrue();
+    assertThat(isValid(minAdapter, -0D)).isTrue();
+    assertThat(isValid(minAdapter, -0L)).isTrue();
+    assertThat(isValid(minAdapter, (short) -0)).isTrue();
+    assertThat(isValid(minAdapter, (byte) -0)).isTrue();
+    assertThat(isValid(minAdapter, BigInteger.valueOf(-0))).isTrue();
+    assertThat(isValid(minAdapter, BigDecimal.valueOf(-0))).isTrue();
   }
 
   @Test
   void testMaxInValid() {
-    assertThat(maxAdapter.validate(01234, request)).isFalse();
-    assertThat(maxAdapter.validate(01234f, request)).isFalse();
-    assertThat(maxAdapter.validate(01234D, request)).isFalse();
-    assertThat(maxAdapter.validate(01234L, request)).isFalse();
-    assertThat(maxAdapter.validate((short) 01234, request)).isFalse();
-    assertThat(maxAdapter.validate((byte) 01234567, request)).isFalse();
-    assertThat(maxAdapter.validate(BigInteger.valueOf(01234), request)).isFalse();
-    assertThat(maxAdapter.validate(BigDecimal.valueOf(01234), request)).isFalse();
+    assertThat(isValid(maxAdapter, 01234)).isFalse();
+    assertThat(isValid(maxAdapter, 01234f)).isFalse();
+    assertThat(isValid(maxAdapter, 01234D)).isFalse();
+    assertThat(isValid(maxAdapter, 01234L)).isFalse();
+    assertThat(isValid(maxAdapter, (short) 01234)).isFalse();
+    assertThat(isValid(maxAdapter, (byte) 01234567)).isFalse();
+    assertThat(isValid(maxAdapter, BigInteger.valueOf(01234))).isFalse();
+    assertThat(isValid(maxAdapter, BigDecimal.valueOf(01234))).isFalse();
   }
 
   @Test
   void testMinInValid() {
-    assertThat(minAdapter.validate(-01234, request)).isFalse();
-    assertThat(minAdapter.validate(-01234f, request)).isFalse();
-    assertThat(minAdapter.validate(-01234D, request)).isFalse();
-    assertThat(minAdapter.validate(-01234L, request)).isFalse();
-    assertThat(minAdapter.validate((short) -01234, request)).isFalse();
-    assertThat(minAdapter.validate((byte) -01234567, request)).isFalse();
-    assertThat(minAdapter.validate(BigInteger.valueOf(-01234), request)).isFalse();
-    assertThat(minAdapter.validate(BigDecimal.valueOf(-01234), request)).isFalse();
+    assertThat(isValid(minAdapter, -01234)).isFalse();
+    assertThat(isValid(minAdapter, -01234f)).isFalse();
+    assertThat(isValid(minAdapter, -01234D)).isFalse();
+    assertThat(isValid(minAdapter, -01234L)).isFalse();
+    assertThat(isValid(minAdapter, (short) -01234)).isFalse();
+    assertThat(isValid(minAdapter, (byte) -01234567)).isFalse();
+    assertThat(isValid(minAdapter, BigInteger.valueOf(-01234))).isFalse();
+    assertThat(isValid(minAdapter, BigDecimal.valueOf(-01234))).isFalse();
   }
 }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/DigitsTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/DigitsTest.java
@@ -26,37 +26,37 @@ class DigitsTest extends BasicTest {
 
   @Test
   void testNull() {
-    assertThat(digitAdapter.validate(null, request)).isTrue();
+    assertThat(isValid(digitAdapter, null)).isTrue();
   }
 
   @Test
   void testValid() {
-    assertThat(digitAdapter.validate(0, request)).isTrue();
-    assertThat(digitAdapter.validate(0f, request)).isTrue();
-    assertThat(digitAdapter.validate(0D, request)).isTrue();
-    assertThat(digitAdapter.validate(0L, request)).isTrue();
-    assertThat(digitAdapter.validate((short) 0, request)).isTrue();
-    assertThat(digitAdapter.validate((byte) 0, request)).isTrue();
-    assertThat(digitAdapter.validate(BigInteger.ZERO, request)).isTrue();
-    assertThat(digitAdapter.validate(BigDecimal.ZERO, request)).isTrue();
+    assertThat(isValid(digitAdapter, 0)).isTrue();
+    assertThat(isValid(digitAdapter, 0f)).isTrue();
+    assertThat(isValid(digitAdapter, 0D)).isTrue();
+    assertThat(isValid(digitAdapter, 0L)).isTrue();
+    assertThat(isValid(digitAdapter, (short) 0)).isTrue();
+    assertThat(isValid(digitAdapter, (byte) 0)).isTrue();
+    assertThat(isValid(digitAdapter, BigInteger.ZERO)).isTrue();
+    assertThat(isValid(digitAdapter, BigDecimal.ZERO)).isTrue();
   }
 
   @Test
   void testInValid() {
-    assertThat(digitAdapter.validate(01234, request)).isTrue();
-    assertThat(digitAdapter.validate(01234f, request)).isTrue();
-    assertThat(digitAdapter.validate(01234D, request)).isTrue();
-    assertThat(digitAdapter.validate(01234L, request)).isTrue();
-    assertThat(digitAdapter.validate((short) 01234, request)).isTrue();
-    assertThat(digitAdapter.validate((byte) 01234, request)).isTrue();
-    assertThat(digitAdapter.validate(BigInteger.valueOf(01234), request)).isTrue();
-    assertThat(digitAdapter.validate(BigDecimal.valueOf(01234), request)).isTrue();
+    assertThat(isValid(digitAdapter, 01234)).isTrue();
+    assertThat(isValid(digitAdapter, 01234f)).isTrue();
+    assertThat(isValid(digitAdapter, 01234D)).isTrue();
+    assertThat(isValid(digitAdapter, 01234L)).isTrue();
+    assertThat(isValid(digitAdapter, (short) 01234)).isTrue();
+    assertThat(isValid(digitAdapter, (byte) 01234)).isTrue();
+    assertThat(isValid(digitAdapter, BigInteger.valueOf(01234))).isTrue();
+    assertThat(isValid(digitAdapter, BigDecimal.valueOf(01234))).isTrue();
   }
 
   @Test
   void testInValidFraction() {
-    assertThat(digitAdapter.validate(0.12345f, request)).isTrue();
-    assertThat(digitAdapter.validate(0.12345D, request)).isTrue();
-    assertThat(digitAdapter.validate(BigDecimal.valueOf(0.12345), request)).isTrue();
+    assertThat(isValid(digitAdapter, 0.12345f)).isTrue();
+    assertThat(isValid(digitAdapter, 0.12345D)).isTrue();
+    assertThat(isValid(digitAdapter, BigDecimal.valueOf(0.12345))).isTrue();
   }
 }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/DigitsTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/DigitsTest.java
@@ -20,8 +20,7 @@ class DigitsTest extends BasicTest {
 
   @Test
   void continueOnInvalid_expect_false() {
-    //BUG: This should really return true? - should continue validation !!
-    assertThat(digitAdapter.validate(BigDecimal.valueOf(0.123456789), request, "foo")).isFalse();
+    assertThat(digitAdapter.validate(BigDecimal.valueOf(0.123456789), request, "foo")).isTrue();
   }
 
   @Test

--- a/validator/src/test/java/io/avaje/validation/core/adapters/DigitsTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/DigitsTest.java
@@ -19,6 +19,12 @@ class DigitsTest extends BasicTest {
       ctx.adapter(Digits.class, Map.of("message", "digimon", "integer", 5, "fraction", 5));
 
   @Test
+  void continueOnInvalid_expect_false() {
+    //BUG: This should really return true? - should continue validation !!
+    assertThat(digitAdapter.validate(BigDecimal.valueOf(0.123456789), request, "foo")).isFalse();
+  }
+
+  @Test
   void testNull() {
     assertThat(digitAdapter.validate(null, request)).isTrue();
   }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/EmailTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/EmailTest.java
@@ -20,8 +20,7 @@ class EmailTest extends BasicTest {
 
   @Test
   void continueOnInvalid_expect_false() {
-    //BUG: This should really return true? - should continue validation !!
-    assertThat(emailAdapter.validate("notAnEmail", request, "foo")).isFalse();
+    assertThat(emailAdapter.validate("notAnEmail", request, "foo")).isTrue();
   }
 
   @Test

--- a/validator/src/test/java/io/avaje/validation/core/adapters/EmailTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/EmailTest.java
@@ -19,6 +19,12 @@ class EmailTest extends BasicTest {
   ValidationAdapter<Object> emailAdapter = ctx.adapter(Email.class, Map.of("message", "email"));
 
   @Test
+  void continueOnInvalid_expect_false() {
+    //BUG: This should really return true? - should continue validation !!
+    assertThat(emailAdapter.validate("notAnEmail", request, "foo")).isFalse();
+  }
+
+  @Test
   void testNull() {
     assertThat(emailAdapter.validate(null, request)).isTrue();
   }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/EmailTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/EmailTest.java
@@ -26,22 +26,22 @@ class EmailTest extends BasicTest {
 
   @Test
   void testNull() {
-    assertThat(emailAdapter.validate(null, request)).isTrue();
+    assertThat(isValid(emailAdapter, null)).isTrue();
   }
 
   @Test
   void testValid() {
-    assertThat(emailAdapter.validate("someEmail@gmail.com", request)).isTrue();
+    assertThat(isValid(emailAdapter, "someEmail@gmail.com")).isTrue();
   }
 
   @Test
   void testBlank() {
-    assertThat(emailAdapter.validate("", request)).isTrue();
-    assertThat(emailAdapter.validate("                    ", request)).isFalse();
+    assertThat(isValid(emailAdapter, "")).isTrue();
+    assertThat(isValid(emailAdapter, "                    ")).isFalse();
   }
 
   @Test
   void testInvalid() {
-    assertThat(emailAdapter.validate("notAnEmail", request)).isFalse();
+    assertThat(isValid(emailAdapter, "notAnEmail")).isFalse();
   }
 }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
@@ -33,9 +33,8 @@ class FuturePastAdapterTest extends BasicTest {
 
   @Test
   void continueOnInvalid_expect_false() {
-    //BUG: This should really return true? - should continue validation !!
-    assertThat(pastAdapter.validate(Instant.now().plusSeconds(100), request, "foo")).isFalse();
-    assertThat(futureAdapter.validate(Instant.now().minusSeconds(100), request, "foo")).isFalse();
+    assertThat(pastAdapter.validate(Instant.now().plusSeconds(100), request, "foo")).isTrue();
+    assertThat(futureAdapter.validate(Instant.now().minusSeconds(100), request, "foo")).isTrue();
   }
 
   @Test

--- a/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
@@ -40,10 +40,10 @@ class FuturePastAdapterTest extends BasicTest {
 
   @Test
   void testNull() {
-    assertThat(pastAdapter.validate(null, request)).isTrue();
-    assertThat(pastOrPresentAdapter.validate(null, request)).isTrue();
-    assertThat(futureAdapter.validate(null, request)).isTrue();
-    assertThat(futureOrPresentAdapter.validate(null, request)).isTrue();
+    assertThat(isValid(pastAdapter, null)).isTrue();
+    assertThat(isValid(pastOrPresentAdapter, null)).isTrue();
+    assertThat(isValid(futureAdapter, null)).isTrue();
+    assertThat(isValid(futureOrPresentAdapter, null)).isTrue();
   }
 
   @Test
@@ -71,21 +71,21 @@ class FuturePastAdapterTest extends BasicTest {
   }
 
   private void assertPast(Object value) {
-    assertThat(pastAdapter.validate(value, request)).isTrue();
-    assertThat(pastOrPresentAdapter.validate(value, request)).isTrue();
-    assertThat(futureAdapter.validate(value, request)).isFalse();
-    assertThat(futureOrPresentAdapter.validate(value, request)).isFalse();
+    assertThat(isValid(pastAdapter, value)).isTrue();
+    assertThat(isValid(pastOrPresentAdapter, value)).isTrue();
+    assertThat(isValid(futureAdapter, value)).isFalse();
+    assertThat(isValid(futureOrPresentAdapter, value)).isFalse();
   }
 
   private void assertFuture(Object value) {
-    assertThat(pastAdapter.validate(value, request)).isFalse();
-    assertThat(pastOrPresentAdapter.validate(value, request)).isFalse();
-    assertThat(futureAdapter.validate(value, request)).isTrue();
-    assertThat(futureOrPresentAdapter.validate(value, request)).isTrue();
+    assertThat(isValid(pastAdapter, value)).isFalse();
+    assertThat(isValid(pastOrPresentAdapter, value)).isFalse();
+    assertThat(isValid(futureAdapter, value)).isTrue();
+    assertThat(isValid(futureOrPresentAdapter, value)).isTrue();
   }
 
   private void assertPresent(Object value) {
-    assertThat(pastOrPresentAdapter.validate(value, request)).isTrue();
-    assertThat(futureOrPresentAdapter.validate(value, request)).isTrue();
+    assertThat(isValid(pastOrPresentAdapter, value)).isTrue();
+    assertThat(isValid(futureOrPresentAdapter, value)).isTrue();
    }
 }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/FuturePastAdapterTest.java
@@ -32,6 +32,13 @@ class FuturePastAdapterTest extends BasicTest {
       ctx.adapter(FutureOrPresent.class, Map.of("message", "wimey", "_type", "Temporal.Instant"));
 
   @Test
+  void continueOnInvalid_expect_false() {
+    //BUG: This should really return true? - should continue validation !!
+    assertThat(pastAdapter.validate(Instant.now().plusSeconds(100), request, "foo")).isFalse();
+    assertThat(futureAdapter.validate(Instant.now().minusSeconds(100), request, "foo")).isFalse();
+  }
+
+  @Test
   void testNull() {
     assertThat(pastAdapter.validate(null, request)).isTrue();
     assertThat(pastOrPresentAdapter.validate(null, request)).isTrue();

--- a/validator/src/test/java/io/avaje/validation/core/adapters/MinMaxTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/MinMaxTest.java
@@ -54,57 +54,57 @@ class MinMaxTest extends BasicTest {
 
   @Test
   void testNull() {
-    assertThat(minBD.validate(null, request)).isTrue();
-    assertThat(maxBD.validate(null, request)).isTrue();
-    assertThat(minLong.validate(null, request)).isTrue();
-    assertThat(maxLong.validate(null, request)).isTrue();
+    assertThat(isValid(minBD, null)).isTrue();
+    assertThat(isValid(maxBD, null)).isTrue();
+    assertThat(isValid(minLong, null)).isTrue();
+    assertThat(isValid(maxLong, null)).isTrue();
   }
 
   @Test
   void testMax() {
-    assertThat(maxLong.validate(0, request)).isTrue();
-    assertThat(maxFloat.validate(0f, request)).isTrue();
-    assertThat(maxDouble.validate(0D, request)).isTrue();
-    assertThat(maxLong.validate(0L, request)).isTrue();
-    assertThat(maxLong.validate((short) 0, request)).isTrue();
-    assertThat(maxLong.validate((byte) 0, request)).isTrue();
-    assertThat(maxBI.validate(BigInteger.valueOf(0), request)).isTrue();
-    assertThat(maxBD.validate(BigDecimal.valueOf(0), request)).isTrue();
+    assertThat(isValid(maxLong, 0)).isTrue();
+    assertThat(isValid(maxFloat, 0f)).isTrue();
+    assertThat(isValid(maxDouble, 0D)).isTrue();
+    assertThat(isValid(maxLong, 0L)).isTrue();
+    assertThat(isValid(maxLong, (short) 0)).isTrue();
+    assertThat(isValid(maxLong, (byte) 0)).isTrue();
+    assertThat(isValid(maxBI, BigInteger.valueOf(0))).isTrue();
+    assertThat(isValid(maxBD, BigDecimal.valueOf(0))).isTrue();
   }
 
   @Test
   void testMin() {
-    assertThat(minLong.validate(-0, request)).isTrue();
-    assertThat(minFloat.validate(-0f, request)).isTrue();
-    assertThat(minDouble.validate(-0D, request)).isTrue();
-    assertThat(minLong.validate(-0L, request)).isTrue();
-    assertThat(minLong.validate((short) -0, request)).isTrue();
-    assertThat(minLong.validate((byte) -0, request)).isTrue();
-    assertThat(minBI.validate(BigInteger.valueOf(-0), request)).isTrue();
-    assertThat(minBD.validate(BigDecimal.valueOf(-0), request)).isTrue();
+    assertThat(isValid(minLong, -0)).isTrue();
+    assertThat(isValid(minFloat, -0f)).isTrue();
+    assertThat(isValid(minDouble, -0D)).isTrue();
+    assertThat(isValid(minLong, -0L)).isTrue();
+    assertThat(isValid(minLong, (short) -0)).isTrue();
+    assertThat(isValid(minLong, (byte) -0)).isTrue();
+    assertThat(isValid(minBI, BigInteger.valueOf(-0))).isTrue();
+    assertThat(isValid(minBD, BigDecimal.valueOf(-0))).isTrue();
   }
 
   @Test
   void testMaxInValid() {
-    assertThat(maxLong.validate(01234, request)).isFalse();
-    assertThat(maxFloat.validate(01234f, request)).isFalse();
-    assertThat(maxDouble.validate(01234D, request)).isFalse();
-    assertThat(maxLong.validate(01234L, request)).isFalse();
-    assertThat(maxLong.validate((short) 01234, request)).isFalse();
-    assertThat(maxLong.validate((byte) 01234567, request)).isFalse();
-    assertThat(maxBI.validate(BigInteger.valueOf(01234), request)).isFalse();
-    assertThat(maxBD.validate(BigDecimal.valueOf(01234), request)).isFalse();
+    assertThat(isValid(maxLong, 01234)).isFalse();
+    assertThat(isValid(maxFloat, 01234f)).isFalse();
+    assertThat(isValid(maxDouble, 01234D)).isFalse();
+    assertThat(isValid(maxLong, 01234L)).isFalse();
+    assertThat(isValid(maxLong, (short) 01234)).isFalse();
+    assertThat(isValid(maxLong, (byte) 01234567)).isFalse();
+    assertThat(isValid(maxBI, BigInteger.valueOf(01234))).isFalse();
+    assertThat(isValid(maxBD, BigDecimal.valueOf(01234))).isFalse();
   }
 
   @Test
   void testMinInValid() {
-    assertThat(minLong.validate(-01234, request)).isFalse();
-    assertThat(minFloat.validate(-01234f, request)).isFalse();
-    assertThat(minDouble.validate(-01234D, request)).isFalse();
-    assertThat(minLong.validate(-01234L, request)).isFalse();
-    assertThat(minLong.validate((short) -01234, request)).isFalse();
-    assertThat(minLong.validate((byte) -01234567, request)).isFalse();
-    assertThat(minBI.validate(BigInteger.valueOf(-01234), request)).isFalse();
-    assertThat(minBD.validate(BigDecimal.valueOf(-01234), request)).isFalse();
+    assertThat(isValid(minLong, -01234)).isFalse();
+    assertThat(isValid(minFloat, -01234f)).isFalse();
+    assertThat(isValid(minDouble, -01234D)).isFalse();
+    assertThat(isValid(minLong, -01234L)).isFalse();
+    assertThat(isValid(minLong, (short) -01234)).isFalse();
+    assertThat(isValid(minLong, (byte) -01234567)).isFalse();
+    assertThat(isValid(minBI, BigInteger.valueOf(-01234))).isFalse();
+    assertThat(isValid(minBD, BigDecimal.valueOf(-01234))).isFalse();
   }
 }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/MinMaxTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/MinMaxTest.java
@@ -47,9 +47,8 @@ class MinMaxTest extends BasicTest {
 
   @Test
   void continueOnInvalid_expect_false() {
-    //BUG: This should really return true? - should continue validation !!
-    assertThat(maxLong.validate(100L, request, "foo")).isFalse();
-    assertThat(minLong.validate(-100L, request, "foo")).isFalse();
+    assertThat(maxLong.validate(100L, request, "foo")).isTrue();
+    assertThat(minLong.validate(-100L, request, "foo")).isTrue();
   }
 
   @Test

--- a/validator/src/test/java/io/avaje/validation/core/adapters/MinMaxTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/MinMaxTest.java
@@ -45,6 +45,12 @@ class MinMaxTest extends BasicTest {
   ValidationAdapter<Object> maxDouble =
     ctx.adapter(Max.class, Map.of("message", "maxwell", "value", 69L, "_type", "Double"));
 
+  @Test
+  void continueOnInvalid_expect_false() {
+    //BUG: This should really return true? - should continue validation !!
+    assertThat(maxLong.validate(100L, request, "foo")).isFalse();
+    assertThat(minLong.validate(-100L, request, "foo")).isFalse();
+  }
 
   @Test
   void testNull() {

--- a/validator/src/test/java/io/avaje/validation/core/adapters/NegativeTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/NegativeTest.java
@@ -38,8 +38,7 @@ class NegativeTest extends BasicTest {
 
   @Test
   void continueOnInvalid_expect_false() {
-    //BUG: This should really return true? - should continue validation !!
-    assertThat(negativeAdapter.validate(1, request, "foo")).isFalse();
+    assertThat(negativeAdapter.validate(1, request, "foo")).isTrue();
   }
 
   @Test

--- a/validator/src/test/java/io/avaje/validation/core/adapters/NegativeTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/NegativeTest.java
@@ -36,6 +36,11 @@ class NegativeTest extends BasicTest {
   ValidationAdapter<Object> negativeOrZeroBI =
     ctx.adapter(NegativeOrZero.class, Map.of("message", "-anate the negative", "_type", "BigInteger"));
 
+  @Test
+  void continueOnInvalid_expect_false() {
+    //BUG: This should really return true? - should continue validation !!
+    assertThat(negativeAdapter.validate(1, request, "foo")).isFalse();
+  }
 
   @Test
   void testNull() {

--- a/validator/src/test/java/io/avaje/validation/core/adapters/NegativeTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/NegativeTest.java
@@ -44,89 +44,89 @@ class NegativeTest extends BasicTest {
 
   @Test
   void testNull() {
-    assertThat(negativeAdapter.validate(null, request)).isTrue();
-    assertThat(negativeOrZeroAdapter.validate(null, request)).isTrue();
+    assertThat(isValid(negativeAdapter, null)).isTrue();
+    assertThat(isValid(negativeOrZeroAdapter, null)).isTrue();
   }
 
   @Test
   void testInfinity() {
-    assertThat(negativeAdapter.validate(Float.POSITIVE_INFINITY, request)).isFalse();
-    assertThat(negativeAdapter.validate(Double.POSITIVE_INFINITY, request)).isFalse();
-    assertThat(negativeOrZeroAdapter.validate(Float.POSITIVE_INFINITY, request)).isFalse();
-    assertThat(negativeOrZeroAdapter.validate(Double.POSITIVE_INFINITY, request)).isFalse();
+    assertThat(isValid(negativeAdapter, Float.POSITIVE_INFINITY)).isFalse();
+    assertThat(isValid(negativeAdapter, Double.POSITIVE_INFINITY)).isFalse();
+    assertThat(isValid(negativeOrZeroAdapter, Float.POSITIVE_INFINITY)).isFalse();
+    assertThat(isValid(negativeOrZeroAdapter, Double.POSITIVE_INFINITY)).isFalse();
 
-    assertThat(negativeAdapter.validate(Float.NEGATIVE_INFINITY, request)).isTrue();
-    assertThat(negativeAdapter.validate(Double.NEGATIVE_INFINITY, request)).isTrue();
-    assertThat(negativeOrZeroAdapter.validate(Float.NEGATIVE_INFINITY, request)).isTrue();
-    assertThat(negativeOrZeroAdapter.validate(Double.NEGATIVE_INFINITY, request)).isTrue();
+    assertThat(isValid(negativeAdapter, Float.NEGATIVE_INFINITY)).isTrue();
+    assertThat(isValid(negativeAdapter, Double.NEGATIVE_INFINITY)).isTrue();
+    assertThat(isValid(negativeOrZeroAdapter, Float.NEGATIVE_INFINITY)).isTrue();
+    assertThat(isValid(negativeOrZeroAdapter, Double.NEGATIVE_INFINITY)).isTrue();
   }
 
   @Test
   void testPositive() {
-    assertThat(negativeString.validate("1", request)).isFalse();
-    assertThat(negativeAdapter.validate(1, request)).isFalse();
-    assertThat(negativeAdapter.validate(1f, request)).isFalse();
-    assertThat(negativeAdapter.validate(1D, request)).isFalse();
-    assertThat(negativeAdapter.validate(1L, request)).isFalse();
-    assertThat(negativeAdapter.validate((short) 1, request)).isFalse();
-    assertThat(negativeAdapter.validate((byte) 1, request)).isFalse();
-    assertThat(negativeBI.validate(BigInteger.ONE, request)).isFalse();
-    assertThat(negativeBD.validate(BigDecimal.ONE, request)).isFalse();
+    assertThat(isValid(negativeString, "1")).isFalse();
+    assertThat(isValid(negativeAdapter, 1)).isFalse();
+    assertThat(isValid(negativeAdapter, 1f)).isFalse();
+    assertThat(isValid(negativeAdapter, 1D)).isFalse();
+    assertThat(isValid(negativeAdapter, 1L)).isFalse();
+    assertThat(isValid(negativeAdapter, (short) 1)).isFalse();
+    assertThat(isValid(negativeAdapter, (byte) 1)).isFalse();
+    assertThat(isValid(negativeBI, BigInteger.ONE)).isFalse();
+    assertThat(isValid(negativeBD, BigDecimal.ONE)).isFalse();
 
-    assertThat(negativeOrZeroString.validate("1", request)).isFalse();
-    assertThat(negativeOrZeroAdapter.validate(1, request)).isFalse();
-    assertThat(negativeOrZeroAdapter.validate(1f, request)).isFalse();
-    assertThat(negativeOrZeroAdapter.validate(1D, request)).isFalse();
-    assertThat(negativeOrZeroAdapter.validate(1L, request)).isFalse();
-    assertThat(negativeOrZeroAdapter.validate((short) 1, request)).isFalse();
-    assertThat(negativeOrZeroAdapter.validate((byte) 1, request)).isFalse();
-    assertThat(negativeOrZeroBI.validate(BigInteger.ONE, request)).isFalse();
-    assertThat(negativeOrZeroBD.validate(BigDecimal.ONE, request)).isFalse();
+    assertThat(isValid(negativeOrZeroString, "1")).isFalse();
+    assertThat(isValid(negativeOrZeroAdapter, 1)).isFalse();
+    assertThat(isValid(negativeOrZeroAdapter, 1f)).isFalse();
+    assertThat(isValid(negativeOrZeroAdapter, 1D)).isFalse();
+    assertThat(isValid(negativeOrZeroAdapter, 1L)).isFalse();
+    assertThat(isValid(negativeOrZeroAdapter, (short) 1)).isFalse();
+    assertThat(isValid(negativeOrZeroAdapter, (byte) 1)).isFalse();
+    assertThat(isValid(negativeOrZeroBI, BigInteger.ONE)).isFalse();
+    assertThat(isValid(negativeOrZeroBD, BigDecimal.ONE)).isFalse();
   }
 
   @Test
   void testNegative() {
-    assertThat(negativeString.validate("-1", request)).isTrue();
-    assertThat(negativeAdapter.validate(-1, request)).isTrue();
-    assertThat(negativeAdapter.validate(-1f, request)).isTrue();
-    assertThat(negativeAdapter.validate(-1D, request)).isTrue();
-    assertThat(negativeAdapter.validate(-1L, request)).isTrue();
-    assertThat(negativeAdapter.validate((short) -1, request)).isTrue();
-    assertThat(negativeAdapter.validate((byte) -1, request)).isTrue();
-    assertThat(negativeBI.validate(BigInteger.valueOf(-1), request)).isTrue();
-    assertThat(negativeBD.validate(BigDecimal.valueOf(-1), request)).isTrue();
+    assertThat(isValid(negativeString, "-1")).isTrue();
+    assertThat(isValid(negativeAdapter, -1)).isTrue();
+    assertThat(isValid(negativeAdapter, -1f)).isTrue();
+    assertThat(isValid(negativeAdapter, -1D)).isTrue();
+    assertThat(isValid(negativeAdapter, -1L)).isTrue();
+    assertThat(isValid(negativeAdapter, (short) -1)).isTrue();
+    assertThat(isValid(negativeAdapter, (byte) -1)).isTrue();
+    assertThat(isValid(negativeBI, BigInteger.valueOf(-1))).isTrue();
+    assertThat(isValid(negativeBD, BigDecimal.valueOf(-1))).isTrue();
 
-    assertThat(negativeOrZeroString.validate("-1", request)).isTrue();
-    assertThat(negativeOrZeroAdapter.validate(-1, request)).isTrue();
-    assertThat(negativeOrZeroAdapter.validate(-1f, request)).isTrue();
-    assertThat(negativeOrZeroAdapter.validate(-1D, request)).isTrue();
-    assertThat(negativeOrZeroAdapter.validate(-1L, request)).isTrue();
-    assertThat(negativeOrZeroAdapter.validate((short) -1, request)).isTrue();
-    assertThat(negativeOrZeroAdapter.validate((byte) -1, request)).isTrue();
-    assertThat(negativeOrZeroBI.validate(BigInteger.valueOf(-1), request)).isTrue();
-    assertThat(negativeOrZeroBD.validate(BigDecimal.valueOf(-1), request)).isTrue();
+    assertThat(isValid(negativeOrZeroString, "-1")).isTrue();
+    assertThat(isValid(negativeOrZeroAdapter, -1)).isTrue();
+    assertThat(isValid(negativeOrZeroAdapter, -1f)).isTrue();
+    assertThat(isValid(negativeOrZeroAdapter, -1D)).isTrue();
+    assertThat(isValid(negativeOrZeroAdapter, -1L)).isTrue();
+    assertThat(isValid(negativeOrZeroAdapter, (short) -1)).isTrue();
+    assertThat(isValid(negativeOrZeroAdapter, (byte) -1)).isTrue();
+    assertThat(isValid(negativeOrZeroBI, BigInteger.valueOf(-1))).isTrue();
+    assertThat(isValid(negativeOrZeroBD, BigDecimal.valueOf(-1))).isTrue();
   }
 
   @Test
   void testZero() {
-    assertThat(negativeString.validate("0", request)).isFalse();
-    assertThat(negativeAdapter.validate(0, request)).isFalse();
-    assertThat(negativeAdapter.validate(0f, request)).isFalse();
-    assertThat(negativeAdapter.validate(0D, request)).isFalse();
-    assertThat(negativeAdapter.validate(0L, request)).isFalse();
-    assertThat(negativeAdapter.validate((short) 0, request)).isFalse();
-    assertThat(negativeAdapter.validate((byte) 0, request)).isFalse();
-    assertThat(negativeBI.validate(BigInteger.ZERO, request)).isFalse();
-    assertThat(negativeBD.validate(BigDecimal.ZERO, request)).isFalse();
+    assertThat(isValid(negativeString, "0")).isFalse();
+    assertThat(isValid(negativeAdapter, 0)).isFalse();
+    assertThat(isValid(negativeAdapter, 0f)).isFalse();
+    assertThat(isValid(negativeAdapter, 0D)).isFalse();
+    assertThat(isValid(negativeAdapter, 0L)).isFalse();
+    assertThat(isValid(negativeAdapter, (short) 0)).isFalse();
+    assertThat(isValid(negativeAdapter, (byte) 0)).isFalse();
+    assertThat(isValid(negativeBI, BigInteger.ZERO)).isFalse();
+    assertThat(isValid(negativeBD, BigDecimal.ZERO)).isFalse();
 
-    assertThat(negativeOrZeroString.validate("0", request)).isTrue();
-    assertThat(negativeOrZeroAdapter.validate(0, request)).isTrue();
-    assertThat(negativeOrZeroAdapter.validate(0f, request)).isTrue();
-    assertThat(negativeOrZeroAdapter.validate(0D, request)).isTrue();
-    assertThat(negativeOrZeroAdapter.validate(0L, request)).isTrue();
-    assertThat(negativeOrZeroAdapter.validate((short) 0, request)).isTrue();
-    assertThat(negativeOrZeroAdapter.validate((byte) 0, request)).isTrue();
-    assertThat(negativeOrZeroBI.validate(BigInteger.ZERO, request)).isTrue();
-    assertThat(negativeOrZeroBD.validate(BigDecimal.ZERO, request)).isTrue();
+    assertThat(isValid(negativeOrZeroString, "0")).isTrue();
+    assertThat(isValid(negativeOrZeroAdapter, 0)).isTrue();
+    assertThat(isValid(negativeOrZeroAdapter, 0f)).isTrue();
+    assertThat(isValid(negativeOrZeroAdapter, 0D)).isTrue();
+    assertThat(isValid(negativeOrZeroAdapter, 0L)).isTrue();
+    assertThat(isValid(negativeOrZeroAdapter, (short) 0)).isTrue();
+    assertThat(isValid(negativeOrZeroAdapter, (byte) 0)).isTrue();
+    assertThat(isValid(negativeOrZeroBI, BigInteger.ZERO)).isTrue();
+    assertThat(isValid(negativeOrZeroBD, BigDecimal.ZERO)).isTrue();
   }
 }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/NotBlankTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/NotBlankTest.java
@@ -19,6 +19,19 @@ class NotBlankTest extends BasicTest {
   ValidationAdapter<Object> notBlankAdapter =
       ctx.adapter(NotBlank.class, Map.of("message", "blank?"));
 
+  ValidationAdapter<Object> notBlankMaxAdapter =
+    ctx.adapter(NotBlank.class, Map.of("message", "blank?", "max", 3));
+
+  @Test
+  void continueOnInvalid_expect_false() {
+    assertThat(notBlankAdapter.validate(null, request, "foo")).isFalse();
+    assertThat(notBlankAdapter.validate("", request, "foo")).isFalse();
+
+    assertThat(notBlankMaxAdapter.validate(null, request, "foo")).isFalse();
+    assertThat(notBlankMaxAdapter.validate("", request, "foo")).isFalse();
+    assertThat(notBlankMaxAdapter.validate("01234", request, "foo")).isFalse();
+  }
+
   @Test
   void testNull() {
     assertThat(notBlankAdapter.validate(null, request)).isFalse();

--- a/validator/src/test/java/io/avaje/validation/core/adapters/NotBlankTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/NotBlankTest.java
@@ -29,7 +29,10 @@ class NotBlankTest extends BasicTest {
 
     assertThat(notBlankMaxAdapter.validate(null, request, "foo")).isFalse();
     assertThat(notBlankMaxAdapter.validate("", request, "foo")).isFalse();
-    assertThat(notBlankMaxAdapter.validate("01234", request, "foo")).isFalse();
+  }
+  @Test
+  void continueOnInvalid_expect_true_when_maxExceeded() {
+    assertThat(notBlankMaxAdapter.validate("01234", request, "foo")).isTrue();
   }
 
   @Test

--- a/validator/src/test/java/io/avaje/validation/core/adapters/NotEmptyTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/NotEmptyTest.java
@@ -32,39 +32,39 @@ class NotEmptyTest extends BasicTest {
 
   @Test
   void testNull() {
-    assertThat(notEmptyAdapter.validate(null, request)).isFalse();
+    assertThat(isValid(notEmptyAdapter, null)).isFalse();
   }
 
   @Test
   void testNotEmpty() {
-    assertThat(notEmptyAdapter.validate("something", request)).isTrue();
+    assertThat(isValid(notEmptyAdapter, "something")).isTrue();
     // length of characters, not whitespace
-    assertThat(notEmptyAdapter.validate("                    ", request)).isTrue();
-    assertThat(notEmptyAdapter.validate(Map.of(1, 2), request)).isTrue();
-    assertThat(notEmptyAdapter.validate(List.of(1), request)).isTrue();
-    assertThat(notEmptyAdapter.validate(Set.of(1), request)).isTrue();
-    assertThat(notEmptyAdapter.validate(new int[] {1}, request)).isTrue();
+    assertThat(isValid(notEmptyAdapter, "                    ")).isTrue();
+    assertThat(isValid(notEmptyAdapter, Map.of(1, 2))).isTrue();
+    assertThat(isValid(notEmptyAdapter, List.of(1))).isTrue();
+    assertThat(isValid(notEmptyAdapter, Set.of(1))).isTrue();
+    assertThat(isValid(notEmptyAdapter, new int[] {1})).isTrue();
   }
 
   @Test
   void testEmpty() {
-    assertThat(notEmptyAdapter.validate(Map.of(), request)).isFalse();
-    assertThat(notEmptyAdapter.validate(List.of(), request)).isFalse();
-    assertThat(notEmptyAdapter.validate(Set.of(), request)).isFalse();
-    assertThat(notEmptyAdapter.validate(new int[] {}, request)).isFalse();
-    assertThat(notEmptyAdapter.validate("", request)).isFalse();
+    assertThat(isValid(notEmptyAdapter, Map.of())).isFalse();
+    assertThat(isValid(notEmptyAdapter, List.of())).isFalse();
+    assertThat(isValid(notEmptyAdapter, Set.of())).isFalse();
+    assertThat(isValid(notEmptyAdapter, new int[] {})).isFalse();
+    assertThat(isValid(notEmptyAdapter, "")).isFalse();
   }
 
   @Test
   void testArrays() {
-    assertThat(notEmptyAdapter.validate(new int[] {1}, request)).isTrue();
-    assertThat(notEmptyAdapter.validate(new byte[] {1}, request)).isTrue();
-    assertThat(notEmptyAdapter.validate(new boolean[] {true}, request)).isTrue();
-    assertThat(notEmptyAdapter.validate(new char[] {'d'}, request)).isTrue();
-    assertThat(notEmptyAdapter.validate(new float[] {1}, request)).isTrue();
-    assertThat(notEmptyAdapter.validate(new short[] {1}, request)).isTrue();
-    assertThat(notEmptyAdapter.validate(new double[] {1}, request)).isTrue();
-    assertThat(notEmptyAdapter.validate(new long[] {1}, request)).isTrue();
-    assertThat(notEmptyAdapter.validate(new String[] {""}, request)).isTrue();
+    assertThat(isValid(notEmptyAdapter, new int[] {1})).isTrue();
+    assertThat(isValid(notEmptyAdapter, new byte[] {1})).isTrue();
+    assertThat(isValid(notEmptyAdapter, new boolean[] {true})).isTrue();
+    assertThat(isValid(notEmptyAdapter, new char[] {'d'})).isTrue();
+    assertThat(isValid(notEmptyAdapter, new float[] {1})).isTrue();
+    assertThat(isValid(notEmptyAdapter, new short[] {1})).isTrue();
+    assertThat(isValid(notEmptyAdapter, new double[] {1})).isTrue();
+    assertThat(isValid(notEmptyAdapter, new long[] {1})).isTrue();
+    assertThat(isValid(notEmptyAdapter, new String[] {""})).isTrue();
   }
 }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/NotEmptyTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/NotEmptyTest.java
@@ -22,6 +22,15 @@ class NotEmptyTest extends BasicTest {
       ctx.adapter(NotEmpty.class, Map.of("message", "this can empty. *chucks it*"));
 
   @Test
+  void continueOnInvalid_expect_false() {
+    assertThat(notEmptyAdapter.validate(null, request, "foo")).isFalse();
+    assertThat(notEmptyAdapter.validate("", request, "foo")).isFalse();
+    assertThat(notEmptyAdapter.validate(List.of(), request, "foo")).isFalse();
+    assertThat(notEmptyAdapter.validate(Map.of(), request, "foo")).isFalse();
+    assertThat(notEmptyAdapter.validate(new int[]{}, request, "foo")).isFalse();
+  }
+
+  @Test
   void testNull() {
     assertThat(notEmptyAdapter.validate(null, request)).isFalse();
   }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/NullableAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/NullableAdapterTest.java
@@ -24,6 +24,12 @@ class NullableAdapterTest extends BasicTest {
       ctx.adapter(NonNull.class, Map.of("message", "Non be null"));
 
   @Test
+  void continueOnInvalid_expect_false() {
+    assertThat(nulladapter.validate(0, request, "foo")).isFalse();
+    assertThat(notNulladapter.validate(null, request, "foo")).isFalse();
+  }
+
+  @Test
   void testNull() {
     assertThat(nulladapter.validate(null, request)).isTrue();
     assertThat(notNulladapter.validate(null, request)).isFalse();

--- a/validator/src/test/java/io/avaje/validation/core/adapters/NullableAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/NullableAdapterTest.java
@@ -31,15 +31,15 @@ class NullableAdapterTest extends BasicTest {
 
   @Test
   void testNull() {
-    assertThat(nulladapter.validate(null, request)).isTrue();
-    assertThat(notNulladapter.validate(null, request)).isFalse();
-    assertThat(nonNulladapter.validate(null, request)).isFalse();
+    assertThat(isValid(nulladapter, null)).isTrue();
+    assertThat(isValid(notNulladapter, null)).isFalse();
+    assertThat(isValid(nonNulladapter, null)).isFalse();
   }
 
   @Test
   void testNotNull() {
-    assertThat(nulladapter.validate(0, request)).isFalse();
-    assertThat(notNulladapter.validate(0, request)).isTrue();
-    assertThat(nonNulladapter.validate(0, request)).isTrue();
+    assertThat(isValid(nulladapter, 0)).isFalse();
+    assertThat(isValid(notNulladapter, 0)).isTrue();
+    assertThat(isValid(nonNulladapter, 0)).isTrue();
   }
 }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/PatternTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/PatternTest.java
@@ -47,12 +47,12 @@ class PatternTest extends BasicTest {
 
   @Test
   void testBlank() {
-    assertThat(patternAdapter.validate("", request)).isFalse();
-    assertThat(patternAdapter.validate("                    ", request)).isFalse();
+    assertThat(isValid(patternAdapter,"")).isFalse();
+    assertThat(isValid(patternAdapter,"                    ")).isFalse();
   }
 
   @Test
   void testInvalid() {
-    assertThat(patternAdapter.validate("notAnEmail", request)).isFalse();
+    assertThat(isValid(patternAdapter,"notAnEmail")).isFalse();
   }
 }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/PatternTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/PatternTest.java
@@ -30,6 +30,12 @@ class PatternTest extends BasicTest {
               List.of(RegexFlag.CANON_EQ)));
 
   @Test
+  void continueOnInvalid_expect_false() {
+    //BUG: Should continue validation - return true!!
+    assertThat(patternAdapter.validate("NotValid", request, "foo")).isFalse();
+  }
+
+  @Test
   void testNull() {
     assertThat(patternAdapter.validate(null, request)).isTrue();
   }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/PatternTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/PatternTest.java
@@ -31,8 +31,7 @@ class PatternTest extends BasicTest {
 
   @Test
   void continueOnInvalid_expect_false() {
-    //BUG: Should continue validation - return true!!
-    assertThat(patternAdapter.validate("NotValid", request, "foo")).isFalse();
+    assertThat(patternAdapter.validate("NotValid", request, "foo")).isTrue();
   }
 
   @Test

--- a/validator/src/test/java/io/avaje/validation/core/adapters/PositiveTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/PositiveTest.java
@@ -29,8 +29,7 @@ class PositiveTest extends BasicTest {
 
   @Test
   void continueOnInvalid_expect_false() {
-    //BUG: Should continue validation? - return true!!
-    assertThat(positiveAdapter.validate(-1, request, "foo")).isFalse();
+    assertThat(positiveAdapter.validate(-1, request, "foo")).isTrue();
   }
 
   @Test

--- a/validator/src/test/java/io/avaje/validation/core/adapters/PositiveTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/PositiveTest.java
@@ -27,6 +27,11 @@ class PositiveTest extends BasicTest {
   ValidationAdapter<Object> positiveOrZeroString =
     ctx.adapter(PositiveOrZero.class, Map.of("message", "-tuate the positive", "_type", "String"));
 
+  @Test
+  void continueOnInvalid_expect_false() {
+    //BUG: Should continue validation? - return true!!
+    assertThat(positiveAdapter.validate(-1, request, "foo")).isFalse();
+  }
 
   @Test
   void testNull() {

--- a/validator/src/test/java/io/avaje/validation/core/adapters/PositiveTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/PositiveTest.java
@@ -35,90 +35,89 @@ class PositiveTest extends BasicTest {
 
   @Test
   void testNull() {
-    assertThat(positiveAdapter.validate(null, request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate(null, request)).isTrue();
+    assertThat(isValid(positiveAdapter, null)).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, null)).isTrue();
   }
 
   @Test
   void testInfinity() {
-    assertThat(positiveAdapter.validate(Float.POSITIVE_INFINITY, request)).isTrue();
-    assertThat(positiveAdapter.validate(Double.POSITIVE_INFINITY, request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate(Float.POSITIVE_INFINITY, request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate(Double.POSITIVE_INFINITY, request)).isTrue();
+    assertThat(isValid(positiveAdapter, Float.POSITIVE_INFINITY)).isTrue();
+    assertThat(isValid(positiveAdapter, Double.POSITIVE_INFINITY)).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, Float.POSITIVE_INFINITY)).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, Double.POSITIVE_INFINITY)).isTrue();
 
-    assertThat(positiveAdapter.validate(Float.NEGATIVE_INFINITY, request)).isFalse();
-    assertThat(positiveAdapter.validate(Double.NEGATIVE_INFINITY, request)).isFalse();
-    assertThat(positiveOrZeroAdapter.validate(Float.NEGATIVE_INFINITY, request)).isFalse();
-    assertThat(positiveOrZeroAdapter.validate(Double.NEGATIVE_INFINITY, request)).isFalse();
+    assertThat(isValid(positiveAdapter, Float.NEGATIVE_INFINITY)).isFalse();
+    assertThat(isValid(positiveAdapter, Double.NEGATIVE_INFINITY)).isFalse();
+    assertThat(isValid(positiveOrZeroAdapter, Float.NEGATIVE_INFINITY)).isFalse();
+    assertThat(isValid(positiveOrZeroAdapter, Double.NEGATIVE_INFINITY)).isFalse();
   }
 
   @Test
   void testPositive() {
-    assertThat(positiveString.validate("1", request)).isTrue();
-    assertThat(positiveAdapter.validate(1, request)).isTrue();
-    assertThat(positiveAdapter.validate(1f, request)).isTrue();
-    assertThat(positiveAdapter.validate(1D, request)).isTrue();
-    assertThat(positiveAdapter.validate(1L, request)).isTrue();
-    assertThat(positiveAdapter.validate((short) 1, request)).isTrue();
-    assertThat(positiveAdapter.validate((byte) 1, request)).isTrue();
-    assertThat(positiveAdapter.validate(BigInteger.ONE, request)).isTrue();
-    assertThat(positiveAdapter.validate(BigDecimal.ONE, request)).isTrue();
+    assertThat(isValid(positiveString, "1")).isTrue();
+    assertThat(isValid(positiveAdapter, 1)).isTrue();
+    assertThat(isValid(positiveAdapter, 1f)).isTrue();
+    assertThat(isValid(positiveAdapter, 1D)).isTrue();
+    assertThat(isValid(positiveAdapter, 1L)).isTrue();
+    assertThat(isValid(positiveAdapter, (short) 1)).isTrue();
+    assertThat(isValid(positiveAdapter, (byte) 1)).isTrue();
+    assertThat(isValid(positiveAdapter, BigInteger.ONE)).isTrue();
+    assertThat(isValid(positiveAdapter, BigDecimal.ONE)).isTrue();
 
-    assertThat(positiveOrZeroString.validate("1", request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate(1, request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate(1f, request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate(1D, request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate(1L, request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate((short) 1, request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate((byte) 1, request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate(BigInteger.ONE, request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate(BigDecimal.ONE, request)).isTrue();
+    assertThat(isValid(positiveOrZeroString, "1")).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, 1)).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, 1f)).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, 1D)).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, 1L)).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, (short) 1)).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, (byte) 1)).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, BigInteger.ONE)).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, BigDecimal.ONE)).isTrue();
   }
 
   @Test
   void testNegative() {
+    assertThat(isValid(positiveString, "-1")).isFalse();
+    assertThat(isValid(positiveAdapter, -1)).isFalse();
+    assertThat(isValid(positiveAdapter, -1f)).isFalse();
+    assertThat(isValid(positiveAdapter, -1D)).isFalse();
+    assertThat(isValid(positiveAdapter, -1L)).isFalse();
+    assertThat(isValid(positiveAdapter, (short) -1)).isFalse();
+    assertThat(isValid(positiveAdapter, (byte) -1)).isFalse();
+    assertThat(isValid(positiveAdapter, BigInteger.valueOf(-1))).isFalse();
+    assertThat(isValid(positiveAdapter, BigDecimal.valueOf(-1))).isFalse();
 
-    assertThat(positiveString.validate("-1", request)).isFalse();
-    assertThat(positiveAdapter.validate(-1, request)).isFalse();
-    assertThat(positiveAdapter.validate(-1f, request)).isFalse();
-    assertThat(positiveAdapter.validate(-1D, request)).isFalse();
-    assertThat(positiveAdapter.validate(-1L, request)).isFalse();
-    assertThat(positiveAdapter.validate((short) -1, request)).isFalse();
-    assertThat(positiveAdapter.validate((byte) -1, request)).isFalse();
-    assertThat(positiveAdapter.validate(BigInteger.valueOf(-1), request)).isFalse();
-    assertThat(positiveAdapter.validate(BigDecimal.valueOf(-1), request)).isFalse();
-
-    assertThat(positiveOrZeroString.validate("-1", request)).isFalse();
-    assertThat(positiveOrZeroAdapter.validate(-1, request)).isFalse();
-    assertThat(positiveOrZeroAdapter.validate(-1f, request)).isFalse();
-    assertThat(positiveOrZeroAdapter.validate(-1D, request)).isFalse();
-    assertThat(positiveOrZeroAdapter.validate(-1L, request)).isFalse();
-    assertThat(positiveOrZeroAdapter.validate((short) -1, request)).isFalse();
-    assertThat(positiveOrZeroAdapter.validate((byte) -1, request)).isFalse();
-    assertThat(positiveOrZeroAdapter.validate(BigInteger.valueOf(-1), request)).isFalse();
-    assertThat(positiveOrZeroAdapter.validate(BigDecimal.valueOf(-1), request)).isFalse();
+    assertThat(isValid(positiveOrZeroString, "-1")).isFalse();
+    assertThat(isValid(positiveOrZeroAdapter, -1)).isFalse();
+    assertThat(isValid(positiveOrZeroAdapter, -1f)).isFalse();
+    assertThat(isValid(positiveOrZeroAdapter, -1D)).isFalse();
+    assertThat(isValid(positiveOrZeroAdapter, -1L)).isFalse();
+    assertThat(isValid(positiveOrZeroAdapter, (short) -1)).isFalse();
+    assertThat(isValid(positiveOrZeroAdapter, (byte) -1)).isFalse();
+    assertThat(isValid(positiveOrZeroAdapter, BigInteger.valueOf(-1))).isFalse();
+    assertThat(isValid(positiveOrZeroAdapter, BigDecimal.valueOf(-1))).isFalse();
   }
 
   @Test
   void testZero() {
-    assertThat(positiveString.validate("0", request)).isFalse();
-    assertThat(positiveAdapter.validate(0, request)).isFalse();
-    assertThat(positiveAdapter.validate(0f, request)).isFalse();
-    assertThat(positiveAdapter.validate(0D, request)).isFalse();
-    assertThat(positiveAdapter.validate(0L, request)).isFalse();
-    assertThat(positiveAdapter.validate((short) 0, request)).isFalse();
-    assertThat(positiveAdapter.validate((byte) 0, request)).isFalse();
-    assertThat(positiveAdapter.validate(BigInteger.ZERO, request)).isFalse();
-    assertThat(positiveAdapter.validate(BigDecimal.ZERO, request)).isFalse();
+    assertThat(isValid(positiveString, "0")).isFalse();
+    assertThat(isValid(positiveAdapter, 0)).isFalse();
+    assertThat(isValid(positiveAdapter, 0f)).isFalse();
+    assertThat(isValid(positiveAdapter, 0D)).isFalse();
+    assertThat(isValid(positiveAdapter, 0L)).isFalse();
+    assertThat(isValid(positiveAdapter, (short) 0)).isFalse();
+    assertThat(isValid(positiveAdapter, (byte) 0)).isFalse();
+    assertThat(isValid(positiveAdapter, BigInteger.ZERO)).isFalse();
+    assertThat(isValid(positiveAdapter, BigDecimal.ZERO)).isFalse();
 
-    assertThat(positiveOrZeroString.validate("0", request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate(0, request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate(0f, request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate(0D, request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate(0L, request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate((short) 0, request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate((byte) 0, request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate(BigInteger.ZERO, request)).isTrue();
-    assertThat(positiveOrZeroAdapter.validate(BigDecimal.ZERO, request)).isTrue();
+    assertThat(isValid(positiveOrZeroString, "0")).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, 0)).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, 0f)).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, 0D)).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, 0L)).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, (short) 0)).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, (byte) 0)).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, BigInteger.ZERO)).isTrue();
+    assertThat(isValid(positiveOrZeroAdapter, BigDecimal.ZERO)).isTrue();
   }
 }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/SizeTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/SizeTest.java
@@ -44,44 +44,44 @@ class SizeTest extends BasicTest {
   @Test
   void testNull() {
     // null elements are considered valid.
-    assertThat(sizeAdapter.validate(null, request)).isTrue();
+    assertThat(isValid(sizeAdapter, null)).isTrue();
   }
 
   @Test
   void testWithinSize() {
-    assertThat(sizeAdapter.validate(Map.of(1, 2,3,4), request)).isTrue();
-    assertThat(sizeAdapter.validate(List.of(1, 2), request)).isTrue();
-    assertThat(sizeAdapter.validate(Set.of(1, 2), request)).isTrue();
-    assertThat(sizeAdapter.validate(new int[] {1, 2,}, request)).isTrue();
-    assertThat(sizeAdapter.validate("12", request)).isTrue();
+    assertThat(isValid(sizeAdapter, Map.of(1, 2,3,4))).isTrue();
+    assertThat(isValid(sizeAdapter, List.of(1, 2))).isTrue();
+    assertThat(isValid(sizeAdapter, Set.of(1, 2))).isTrue();
+    assertThat(isValid(sizeAdapter, new int[] {1, 2,})).isTrue();
+    assertThat(isValid(sizeAdapter, "12")).isTrue();
   }
 
   @Test
   void testSmallerSize() {
-    assertThat(sizeAdapter.validate("1", request)).isFalse();
+    assertThat(isValid(sizeAdapter, "1")).isFalse();
     // if greater than 0 continue validation
-    assertThat(sizeAdapter.validate(Map.of(1, 2), request)).isTrue();
-    assertThat(sizeAdapter.validate(List.of(1), request)).isTrue();
-    assertThat(sizeAdapter.validate(Set.of(1), request)).isTrue();
-    assertThat(sizeAdapter.validate(new int[] {1}, request)).isTrue();
+    assertThat(isValid(sizeAdapter, Map.of(1, 2))).isFalse();
+    assertThat(isValid(sizeAdapter, List.of(1))).isFalse();
+    assertThat(isValid(sizeAdapter, Set.of(1))).isFalse();
+    assertThat(isValid(sizeAdapter, new int[] {1})).isFalse();
   }
 
   @Test
   void test0Size() {
-    assertThat(sizeAdapter.validate(Map.of(), request)).isFalse();
-    assertThat(sizeAdapter.validate(List.of(), request)).isFalse();
-    assertThat(sizeAdapter.validate(Set.of(), request)).isFalse();
-    assertThat(sizeAdapter.validate(new int[] {}, request)).isFalse();
-    assertThat(sizeAdapter.validate("", request)).isFalse();
+    assertThat(isValid(sizeAdapter, Map.of())).isFalse();
+    assertThat(isValid(sizeAdapter, List.of())).isFalse();
+    assertThat(isValid(sizeAdapter, Set.of())).isFalse();
+    assertThat(isValid(sizeAdapter, new int[] {})).isFalse();
+    assertThat(isValid(sizeAdapter, "")).isFalse();
   }
 
   @Test
   void testBiggerSize() {
-    assertThat(sizeAdapter.validate("it's too big", request)).isFalse();
+    assertThat(isValid(sizeAdapter, "it's too big")).isFalse();
     // if greater than 0 continue validation
-    assertThat(sizeAdapter.validate(Map.of(1, 2, 3, 4, 5, 6, 7, 8), request)).isTrue();
-    assertThat(sizeAdapter.validate(List.of(1, 2, 3, 4), request)).isTrue();
-    assertThat(sizeAdapter.validate(Set.of(1, 2, 3, 4), request)).isTrue();
-    assertThat(sizeAdapter.validate(new int[] {1, 2, 3, 4}, request)).isTrue();
+    assertThat(isValid(sizeAdapter, Map.of(1, 2, 3, 4, 5, 6, 7, 8))).isFalse();
+    assertThat(isValid(sizeAdapter, List.of(1, 2, 3, 4))).isFalse();
+    assertThat(isValid(sizeAdapter, Set.of(1, 2, 3, 4))).isFalse();
+    assertThat(isValid(sizeAdapter, new int[] {1, 2, 3, 4})).isFalse();
   }
 }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/SizeTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/SizeTest.java
@@ -23,9 +23,8 @@ class SizeTest extends BasicTest {
 
   @Test
   void continueOnInvalid_expect_false_when_string() {
-    //BUG?: Should it continue validation? Prevents further pattern validations
-    assertThat(sizeAdapter.validate("a", request, "foo")).isFalse();
-    assertThat(sizeAdapter.validate("abcde", request, "foo")).isFalse();
+    assertThat(sizeAdapter.validate("a", request, "foo")).isTrue();
+    assertThat(sizeAdapter.validate("abcde", request, "foo")).isTrue();
   }
 
   @Test

--- a/validator/src/test/java/io/avaje/validation/core/adapters/SizeTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/SizeTest.java
@@ -22,6 +22,26 @@ class SizeTest extends BasicTest {
       ctx.adapter(Size.class, Map.of("message", "blank?", "min", 2, "max", 3));
 
   @Test
+  void continueOnInvalid_expect_false_when_string() {
+    //BUG?: Should it continue validation? Prevents further pattern validations
+    assertThat(sizeAdapter.validate("a", request, "foo")).isFalse();
+    assertThat(sizeAdapter.validate("abcde", request, "foo")).isFalse();
+  }
+
+  @Test
+  void continueOnInvalid_expect_true_when_collection() {
+    assertThat(sizeAdapter.validate(List.of(1), request, "foo")).isTrue();
+    assertThat(sizeAdapter.validate(List.of(1, 2, 3, 4), request, "foo")).isTrue();
+  }
+
+  @Test
+  void continueOnInvalid_expect_false_when_collectionEmpty() {
+    assertThat(sizeAdapter.validate(List.of(), request, "foo")).isFalse();
+    assertThat(sizeAdapter.validate(Map.of(), request, "foo")).isFalse();
+    assertThat(sizeAdapter.validate(new int[]{}, request, "foo")).isFalse();
+  }
+
+  @Test
   void testNull() {
     // null elements are considered valid.
     assertThat(sizeAdapter.validate(null, request)).isTrue();


### PR DESCRIPTION
Change AbstractConstraintAdapter to continue validation, Adjust NullableAdapter and NotEmptyAdapter to support existing behaviour

Note that the original failing test was for multiple `@Pattern` validations on the same field. The issue was that the validation would not correctly process the entire chain of validation adapters because some [like the PatternAdapter] were incorrectly returning false to stop the validation when they added a constraint violation.

The fix was a combination of changing AbstractConstraintAdapter to continue validation, plus changing NullableAdapter and NotEmptyAdapter to support existing behaviour.
