### PR TITLE
Fix NPE when cascade @Valid on nullable pojo

### DIFF
--- a/blackbox-test/src/main/java/example/avaje/cascade/MAddress.java
+++ b/blackbox-test/src/main/java/example/avaje/cascade/MAddress.java
@@ -1,0 +1,14 @@
+package example.avaje.cascade;
+
+import io.avaje.validation.constraints.NotBlank;
+import io.avaje.validation.constraints.Size;
+import io.avaje.validation.constraints.Valid;
+
+@Valid
+public class MAddress {
+
+  @NotBlank @Size(max = 10)
+  public String line1;
+  public String line2;
+
+}

--- a/blackbox-test/src/main/java/example/avaje/cascade/MCustomer.java
+++ b/blackbox-test/src/main/java/example/avaje/cascade/MCustomer.java
@@ -1,0 +1,58 @@
+package example.avaje.cascade;
+
+import io.avaje.validation.constraints.NotBlank;
+import io.avaje.validation.constraints.NotNull;
+import io.avaje.validation.constraints.Valid;
+
+import java.time.LocalDate;
+
+@Valid
+public class MCustomer {
+
+  boolean active;
+
+  @NotBlank(max = 20)
+  String name;
+
+  @NotNull
+  LocalDate activeDate;
+
+  @Valid
+  MAddress billingAddress;
+
+  public MCustomer setActive(boolean active) {
+    this.active = active;
+    return this;
+  }
+
+  public MCustomer setName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public MCustomer setActiveDate(LocalDate activeDate) {
+    this.activeDate = activeDate;
+    return this;
+  }
+
+  public MCustomer setBillingAddress(MAddress billingAddress) {
+    this.billingAddress = billingAddress;
+    return this;
+  }
+
+  public boolean active() {
+    return active;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public LocalDate activeDate() {
+    return activeDate;
+  }
+
+  public MAddress billingAddress() {
+    return billingAddress;
+  }
+}

--- a/blackbox-test/src/test/java/example/avaje/cascade/MCustomerTest.java
+++ b/blackbox-test/src/test/java/example/avaje/cascade/MCustomerTest.java
@@ -1,0 +1,23 @@
+package example.avaje.cascade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import io.avaje.validation.Validator;
+
+import java.time.LocalDate;
+
+class MCustomerTest {
+
+  Validator validator = Validator.builder().build();
+
+  @Test
+  void valid() {
+    var customer = new MCustomer()
+      .setName("Foo")
+      .setActiveDate(LocalDate.now())
+      .setActive(true);
+
+    validator.validate(customer);
+  }
+}

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ClassReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ClassReader.java
@@ -106,7 +106,6 @@ final class ClassReader implements BeanReader {
 
   @Override
   public void writeFields(Append writer) {
-
     for (final FieldReader allField : allFields) {
       allField.writeField(writer);
     }
@@ -125,6 +124,7 @@ final class ClassReader implements BeanReader {
     writer.eol();
     writer.append("  @Override").eol();
     writer.append("  public boolean validate(%s value, ValidationRequest request, String field) {", shortName).eol();
+    writer.append("    if (value == null) return true; // continue validation").eol();
     writer.append("    if (field != null) {").eol();
     writer.append("      request.pushPath(field);").eol();
     writer.append("    }").eol();


### PR DESCRIPTION
When cascading via @Valid on a related pojo that can be nullable, this can generate an NPE.

Fix is to change the generated code for pojo adapters to check for the value/pojo to be null and skip the validation in that case