### PR TITLE
Change andThen() to continue false when first validator is false

### DIFF
--- a/validator/src/main/java/io/avaje/validation/adapter/ValidationAdapter.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/ValidationAdapter.java
@@ -97,7 +97,7 @@ public interface ValidationAdapter<T> {
       if (validate(value, req, propertyName)) {
         return after.validate(value, req, propertyName);
       }
-      return true;
+      return false;
     };
   }
 

--- a/validator/src/test/java/io/avaje/validation/core/adapters/NullableAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/NullableAdapterTest.java
@@ -30,6 +30,18 @@ class NullableAdapterTest extends BasicTest {
   }
 
   @Test
+  void andThenContinue_expect_false() {
+    ValidationAdapter<Object> otherAdapter =
+      ctx.adapter(SizeTest.Size.class, Map.of("message", "blank?", "min", 2, "max", 3));
+
+    var combinedAndThen =
+       ctx.<String>adapter(NotNull.class, Map.of("message", "myCustomNullMessage"))
+      .andThen(otherAdapter);
+
+    assertThat(combinedAndThen.validate(null, request, "foo")).isFalse();
+  }
+
+  @Test
   void testNull() {
     assertThat(isValid(nulladapter, null)).isTrue();
     assertThat(isValid(notNulladapter, null)).isFalse();


### PR DESCRIPTION
This is fixing a semantic bug (that has no impact because the validation chain stops anyway) to return false indicating that the validation shouldn't continue.

It has no impact because currently the generated code uses a single chain and that DOES actually stop processing (but then just returns the wrong value).

Tidy this up so that a followup refactor turning this into a lambda is then no behaviour change.