### PR TITLE
Refactor CoreAdapterBuilder cache use

### DIFF
--- a/validator/src/main/java/io/avaje/validation/core/CoreAdapterBuilder.java
+++ b/validator/src/main/java/io/avaje/validation/core/CoreAdapterBuilder.java
@@ -54,18 +54,6 @@ final class CoreAdapterBuilder {
 
   /** Build for the simple non-annotated type case. */
   <T> ValidationAdapter<T> build(Type type) {
-    return build(type, type);
-  }
-
-  <T> ValidationAdapter<T> annotationAdapter(
-      Class<? extends Annotation> cls, Map<String, Object> attributes, Set<Class<?>> groups) {
-    return buildAnnotation(cls, attributes, groups);
-  }
-
-  /** Build given type and annotations. */
-  // TODO understand that lookup chain stuff
-  @SuppressWarnings("unchecked")
-  <T> ValidationAdapter<T> build(Type type, Object cacheKey) {
     // Ask each factory to create the validation adapter.
     for (final AdapterFactory factory : factories) {
       final var result = (ValidationAdapter<T>) factory.create(type, context);
@@ -74,6 +62,11 @@ final class CoreAdapterBuilder {
       }
     }
     throw new IllegalArgumentException("No ValidationAdapter for " + type + ". Perhaps needs @Valid or @Valid.Import?");
+  }
+
+  <T> ValidationAdapter<T> annotationAdapter(
+      Class<? extends Annotation> cls, Map<String, Object> attributes, Set<Class<?>> groups) {
+    return buildAnnotation(cls, attributes, groups);
   }
 
   /**

--- a/validator/src/main/java/io/avaje/validation/core/DValidator.java
+++ b/validator/src/main/java/io/avaje/validation/core/DValidator.java
@@ -152,13 +152,12 @@ final class DValidator implements Validator, ValidationContext {
 
   @Override
   public <T> ValidationAdapter<T> adapter(Type type) {
-    type = removeSubtypeWildcard(canonicalize(requireNonNull(type)));
-    final Object cacheKey = type;
+    final Type cacheKey = removeSubtypeWildcard(canonicalize(requireNonNull(type)));
     final ValidationAdapter<T> result = builder.get(cacheKey);
     if (result != null) {
       return result;
     }
-    return builder.build(type, cacheKey);
+    return builder.build(cacheKey);
   }
 
   @Override


### PR DESCRIPTION
We can merge the 2 build() methods because the cacheKey is always just the type.