### PR TITLE
Add support for sharing instances of NotNull NotBlank adapters

### DIFF
--- a/validator/src/main/java/io/avaje/validation/adapter/ValidationContext.java
+++ b/validator/src/main/java/io/avaje/validation/adapter/ValidationContext.java
@@ -116,6 +116,7 @@ public interface ValidationContext {
      */
     String lookupkey();
   }
+
   /** Request to create a Validation Adapter. */
   interface AdapterCreateRequest {
 
@@ -132,7 +133,7 @@ public interface ValidationContext {
     Map<String, Object> attributes();
 
     /** Return the attribute for the given key. */
-   <T> T attribute(String key);
+    <T> T attribute(String key);
 
     /** Return the message to use */
     Message message();
@@ -143,7 +144,19 @@ public interface ValidationContext {
     /** Return the target type */
     String targetType();
 
+    /** Return true if the groups is ONLY the default group */
+    boolean isDefaultGroupOnly();
+
     /** Clone and return the request with a new value attribute */
     AdapterCreateRequest withValue(long value);
+  }
+
+  /** Used to build default ValidationAdapters with the default group and message. */
+  interface RequestBuilder {
+
+    /**
+     * Build a default AdapterCreateRequest with the appropriate default message.
+     */
+    AdapterCreateRequest defaultRequest(String defaultMessage);
   }
 }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/NotBlankTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/NotBlankTest.java
@@ -30,6 +30,7 @@ class NotBlankTest extends BasicTest {
     assertThat(notBlankMaxAdapter.validate(null, request, "foo")).isFalse();
     assertThat(notBlankMaxAdapter.validate("", request, "foo")).isFalse();
   }
+
   @Test
   void continueOnInvalid_expect_true_when_maxExceeded() {
     assertThat(notBlankMaxAdapter.validate("01234", request, "foo")).isTrue();
@@ -49,5 +50,20 @@ class NotBlankTest extends BasicTest {
   void testBlank() {
     assertThat(notBlankAdapter.validate("", request)).isFalse();
     assertThat(notBlankAdapter.validate("                    ", request)).isFalse();
+  }
+
+  @Test
+  void defaultInstance() {
+    var adapter0 = ctx.adapter(NotBlank.class, Map.of("message", "{avaje.NotBlank.message}"));
+    var adapter1 = ctx.adapter(NotBlank.class, Map.of("message", "{avaje.NotBlank.message}"));
+    var adapter2 = ctx.adapter(NotBlank.class, Map.of("message", "{avaje.NotBlank.message}", "max", 0));
+    assertThat(adapter1).isSameAs(adapter0).isSameAs(adapter2);
+
+    // these are different instances
+    var adapterDiff1 = ctx.adapter(NotBlank.class, Map.of("message", "Other message"));
+    var adapterDiff2 = ctx.adapter(NotBlank.class, Map.of("message", "{avaje.NotBlank.message}", "max", 4));
+    assertThat(adapter0).isNotSameAs(adapterDiff1);
+    assertThat(adapter0).isNotSameAs(adapterDiff2);
+    assertThat(adapterDiff1).isNotSameAs(adapterDiff2);
   }
 }

--- a/validator/src/test/java/io/avaje/validation/core/adapters/NullableAdapterTest.java
+++ b/validator/src/test/java/io/avaje/validation/core/adapters/NullableAdapterTest.java
@@ -3,7 +3,9 @@ package io.avaje.validation.core.adapters;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
+import java.util.Set;
 
+import io.avaje.validation.groups.Default;
 import org.junit.jupiter.api.Test;
 
 import io.avaje.validation.adapter.ValidationAdapter;
@@ -41,5 +43,18 @@ class NullableAdapterTest extends BasicTest {
     assertThat(isValid(nulladapter, 0)).isFalse();
     assertThat(isValid(notNulladapter, 0)).isTrue();
     assertThat(isValid(nonNulladapter, 0)).isTrue();
+  }
+
+  @Test
+  void defaultInstance() {
+    var adapter0 = ctx.adapter(NotNull.class, Map.of("message", "{avaje.NotNull.message}"));
+    var adapter1 = ctx.adapter(NotNull.class, Map.of("message", "{avaje.NotNull.message}"));
+    var adapter2 = ctx.adapter(NotNull.class, Set.of(Default.class), "{avaje.NotNull.message}", Map.of("message", "{avaje.NotNull.message}"));
+    assertThat(adapter1).isSameAs(adapter0).isSameAs(adapter2);
+
+    // these are different instances
+    var adapterDiff1 = ctx.adapter(NotNull.class, Map.of("message", "Other message"));
+    var adapterDiff2 = ctx.adapter(NotNull.class, Set.of(NullableAdapterTest.class), "{avaje.NotNull.message}", Map.of("message", "{avaje.NotNull.message}"));
+    assertThat(adapter0).isNotSameAs(adapterDiff1).isNotSameAs(adapterDiff2);
   }
 }


### PR DESCRIPTION
When these are not customised and use the default group and default message, we can use shared "default adapters" instead of creating a new adapter for each instance.

This will be beneficial (reduce memory consumption) for the case where lots of NotNull & NotBlank etc used without any customisation of the groups or message.

This approach can be extended to also apply to other common validators like Email, UUID, AssertTrue, Positive etc.