### PR TITLE
Add `@ValidSubTypes`

### DIFF
--- a/blackbox-test/src/main/java/example/avaje/subtypes/ByIdSelector.java
+++ b/blackbox-test/src/main/java/example/avaje/subtypes/ByIdSelector.java
@@ -1,0 +1,8 @@
+package example.avaje.subtypes;
+
+import java.util.List;
+import java.util.UUID;
+
+import io.avaje.validation.constraints.NotEmpty;
+
+public final record ByIdSelector(@NotEmpty List<UUID> ids) implements EntitySelector {}

--- a/blackbox-test/src/main/java/example/avaje/subtypes/ByQuerySelector.java
+++ b/blackbox-test/src/main/java/example/avaje/subtypes/ByQuerySelector.java
@@ -1,4 +1,4 @@
-package io.avaje.validation.generator.models.valid.subtypes;
+package example.avaje.subtypes;
 
 import io.avaje.validation.constraints.NotBlank;
 

--- a/blackbox-test/src/main/java/example/avaje/subtypes/EntitySelector.java
+++ b/blackbox-test/src/main/java/example/avaje/subtypes/EntitySelector.java
@@ -1,6 +1,6 @@
 package example.avaje.subtypes;
 
-import io.avaje.validation.SubTypes;
+import io.avaje.validation.ValidSubTypes;
 
-@SubTypes({ByQuerySelector.class, ByIdSelector.class})
+@ValidSubTypes({ByQuerySelector.class, ByIdSelector.class})
 public interface EntitySelector {}

--- a/blackbox-test/src/main/java/example/avaje/subtypes/EntitySelector.java
+++ b/blackbox-test/src/main/java/example/avaje/subtypes/EntitySelector.java
@@ -1,0 +1,6 @@
+package example.avaje.subtypes;
+
+import io.avaje.validation.SubTypes;
+
+@SubTypes({ByQuerySelector.class, ByIdSelector.class})
+public interface EntitySelector {}

--- a/blackbox-test/src/main/java/example/avaje/subtypes/SubtypeEntity.java
+++ b/blackbox-test/src/main/java/example/avaje/subtypes/SubtypeEntity.java
@@ -1,0 +1,6 @@
+package example.avaje.subtypes;
+
+import jakarta.validation.Valid;
+
+@Valid
+public record SubtypeEntity(@Valid EntitySelector selector) {}

--- a/blackbox-test/src/main/java/example/avaje/subtypes/sealed/ByIdSelectorSealed.java
+++ b/blackbox-test/src/main/java/example/avaje/subtypes/sealed/ByIdSelectorSealed.java
@@ -1,15 +1,15 @@
-package io.avaje.validation.generator.models.valid.subtypes;
+package example.avaje.subtypes.sealed;
 
 import java.util.List;
 import java.util.UUID;
 
 import io.avaje.validation.constraints.NotEmpty;
 
-public final class ByIdSelector implements EntitySelector {
+public final class ByIdSelectorSealed implements SealedEntitySelector {
 
   @NotEmpty private final List<UUID> ids;
 
-  public ByIdSelector(List<UUID> ids) {
+  public ByIdSelectorSealed(@NotEmpty List<UUID> ids) {
     this.ids = ids;
   }
 

--- a/blackbox-test/src/main/java/example/avaje/subtypes/sealed/ByQuerySelectorSealed.java
+++ b/blackbox-test/src/main/java/example/avaje/subtypes/sealed/ByQuerySelectorSealed.java
@@ -1,0 +1,5 @@
+package example.avaje.subtypes.sealed;
+
+import io.avaje.validation.constraints.NotBlank;
+
+public final record ByQuerySelectorSealed(@NotBlank String query) implements SealedEntitySelector {}

--- a/blackbox-test/src/main/java/example/avaje/subtypes/sealed/SealedEntity.java
+++ b/blackbox-test/src/main/java/example/avaje/subtypes/sealed/SealedEntity.java
@@ -1,0 +1,6 @@
+package example.avaje.subtypes.sealed;
+
+import jakarta.validation.Valid;
+
+@Valid
+public record SealedEntity(@Valid SealedEntitySelector selector) {}

--- a/blackbox-test/src/main/java/example/avaje/subtypes/sealed/SealedEntitySelector.java
+++ b/blackbox-test/src/main/java/example/avaje/subtypes/sealed/SealedEntitySelector.java
@@ -1,0 +1,15 @@
+package example.avaje.subtypes.sealed;
+
+import java.util.List;
+import java.util.UUID;
+
+import example.avaje.subtypes.sealed.SealedEntitySelector.NestedSealed;
+import io.avaje.validation.SubTypes;
+import io.avaje.validation.constraints.NotEmpty;
+
+@SubTypes
+public sealed interface SealedEntitySelector
+    permits ByQuerySelectorSealed, ByIdSelectorSealed, NestedSealed {
+
+  public final record NestedSealed(@NotEmpty List<UUID> ids) implements SealedEntitySelector {}
+}

--- a/blackbox-test/src/main/java/example/avaje/subtypes/sealed/SealedEntitySelector.java
+++ b/blackbox-test/src/main/java/example/avaje/subtypes/sealed/SealedEntitySelector.java
@@ -4,10 +4,10 @@ import java.util.List;
 import java.util.UUID;
 
 import example.avaje.subtypes.sealed.SealedEntitySelector.NestedSealed;
-import io.avaje.validation.SubTypes;
+import io.avaje.validation.ValidSubTypes;
 import io.avaje.validation.constraints.NotEmpty;
 
-@SubTypes
+@ValidSubTypes
 public sealed interface SealedEntitySelector
     permits ByQuerySelectorSealed, ByIdSelectorSealed, NestedSealed {
 

--- a/blackbox-test/src/test/java/example/avaje/subtypes/EntitySelectorTest.java
+++ b/blackbox-test/src/test/java/example/avaje/subtypes/EntitySelectorTest.java
@@ -1,0 +1,27 @@
+package example.avaje.subtypes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.Validator;
+
+class EntitySelectorTest {
+
+  Validator validator = Validator.builder().build();
+
+  @Test
+  void validByIdSelector() {
+    var entity = new SubtypeEntity(new ByIdSelector(List.of()));
+
+    assertThat(validator.check(entity).iterator().next().message()).isEqualTo("must not be empty");
+  }
+
+  @Test
+  void validByIdQuery() {
+    var entity = new SubtypeEntity(new ByQuerySelector(""));
+    assertThat(validator.check(entity).iterator().next().message()).isEqualTo("must not be blank");
+  }
+}

--- a/blackbox-test/src/test/java/example/avaje/subtypes/sealed/SealedEntitySelectorTest.java
+++ b/blackbox-test/src/test/java/example/avaje/subtypes/sealed/SealedEntitySelectorTest.java
@@ -1,0 +1,27 @@
+package example.avaje.subtypes.sealed;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.Validator;
+
+class SealedEntitySelectorTest {
+
+  Validator validator = Validator.builder().build();
+
+  @Test
+  void validByIdSelector() {
+    var entity = new SealedEntity(new ByIdSelectorSealed(List.of()));
+
+    assertThat(validator.check(entity).iterator().next().message()).isEqualTo("must not be empty");
+  }
+
+  @Test
+  void validByIdQuery() {
+    var entity = new SealedEntity(new ByQuerySelectorSealed(""));
+    assertThat(validator.check(entity).iterator().next().message()).isEqualTo("must not be blank");
+  }
+}

--- a/blackbox-test/src/test/java/example/avaje/typeuse/DefaultValidatorProviderTest.java
+++ b/blackbox-test/src/test/java/example/avaje/typeuse/DefaultValidatorProviderTest.java
@@ -8,15 +8,15 @@ import org.junit.jupiter.api.Test;
 
 import io.avaje.http.api.ValidationException;
 import io.avaje.http.api.Validator;
+import io.avaje.inject.spi.AvajeModule;
 import io.avaje.inject.spi.Builder;
-import io.avaje.inject.spi.Module;
 import io.avaje.inject.test.InjectTest;
 import jakarta.inject.Inject;
 
 @InjectTest
 class DefaultValidatorProviderTest {
-  Module mod =
-      new Module() {
+  AvajeModule mod =
+      new AvajeModule() {
 
         @Override
         public Class<?>[] classes() {

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
     <maven.compiler.release>17</maven.compiler.release>
     <inject.version>10.3</inject.version>
-    <spi.version>2.5</spi.version>
+    <spi.version>2.9</spi.version>
     <project.build.outputTimestamp>2025-02-10T08:50:36Z</project.build.outputTimestamp>
   </properties>
 

--- a/validator-generator/pom.xml
+++ b/validator-generator/pom.xml
@@ -14,6 +14,7 @@
   <description>annotation processor generating validation adapters</description>
   <properties>
     <avaje.prisms.version>1.38</avaje.prisms.version>
+    <io.jstach.version>1.3.6</io.jstach.version>
   </properties>
 
   <dependencies>
@@ -66,6 +67,22 @@
       <optional>true</optional>
       <scope>provided</scope>
     </dependency>
+    
+    <dependency>
+        <groupId>io.jstach</groupId>
+        <artifactId>jstachio-annotation</artifactId>
+        <version>${io.jstach.version}</version>
+        <optional>true</optional>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>io.jstach</groupId>
+        <artifactId>jstachio-apt</artifactId>
+        <version>${io.jstach.version}</version>
+        <optional>true</optional>
+        <scope>provided</scope>
+    </dependency>
+    
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>

--- a/validator-generator/src/main/java/io/avaje/validation/generator/SubTypeWriter.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/SubTypeWriter.java
@@ -15,10 +15,7 @@ import javax.lang.model.type.TypeMirror;
 import javax.tools.JavaFileObject;
 
 import io.jstach.jstache.JStache;
-import io.jstach.jstache.JStacheConfig;
-import io.jstach.jstache.JStacheType;
 
-@JStacheConfig(type = JStacheType.STACHE)
 public class SubTypeWriter {
 
   TypeElement element;

--- a/validator-generator/src/main/java/io/avaje/validation/generator/SubTypeWriter.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/SubTypeWriter.java
@@ -1,0 +1,152 @@
+package io.avaje.validation.generator;
+
+import static io.avaje.validation.generator.APContext.createSourceFile;
+import static io.avaje.validation.generator.APContext.logError;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.tools.JavaFileObject;
+
+import io.jstach.jstache.JStache;
+
+public class SubTypeWriter {
+
+  TypeElement element;
+  List<String> subtypeStrings;
+  private final Set<String> importTypes = new TreeSet<>();
+  private final String shortName;
+  private final String adapterPackage;
+  private final String adapterFullName;
+  private final String shortType;
+
+  public SubTypeWriter(TypeElement element, List<TypeMirror> subtypes) {
+    this.element = element;
+    this.subtypeStrings =
+        subtypes.stream().map(TypeMirror::toString).map(ProcessorUtils::shortType).toList();
+    final AdapterName adapterName = new AdapterName(element);
+    this.shortName = adapterName.shortName();
+    this.adapterPackage = adapterName.adapterPackage();
+    this.adapterFullName = adapterName.fullName();
+    this.shortType = element.getQualifiedName().toString().transform(ProcessorUtils::shortType);
+
+    importTypes.add("io.avaje.validation.adapter.ValidationAdapter");
+    importTypes.add("io.avaje.validation.adapter.ValidationContext");
+    importTypes.add("io.avaje.validation.adapter.ValidationRequest");
+    importTypes.add("io.avaje.validation.spi.Generated");
+    subtypes.stream().map(TypeMirror::toString).forEach(importTypes::add);
+  }
+
+  private Writer createFileWriter() throws IOException {
+    final JavaFileObject jfo = createSourceFile(adapterFullName);
+    return jfo.openWriter();
+  }
+
+  void write() {
+    Append writer;
+    try {
+      writer = new Append(createFileWriter());
+      var validation =
+          APContext.jdkVersion() > 17
+              ? new SwitchValidation(
+                      subtypeStrings, element.getModifiers().contains(Modifier.SEALED))
+                  .render()
+              : new IfValidation(subtypeStrings).render();
+
+      var template =
+          new SubTemplate(
+                  adapterPackage, importTypes, shortName, shortType, subtypeStrings, validation)
+              .render();
+
+      writer.append(template).close();
+    } catch (IOException e) {
+
+      logError("Error writing ValidationAdapter for %s %s", element, e);
+    }
+  }
+
+  String fullName() {
+    return adapterFullName;
+  }
+
+  @JStache(
+      template =
+          """
+      package {{packageName}};
+
+      {{#imports}}
+      import {{.}};
+      {{/imports}}
+
+      @Generated("avaje-validation-generator")
+      public class {{shortName}}ValidationAdapter implements ValidationAdapter<{{shortType}}> {
+
+      {{#subtypes}}
+        private final ValidationAdapter<{{.}}> subAdapter{{@index}};
+      {{/subtypes}}
+
+        public {{shortName}}ValidationAdapter(ValidationContext ctx) {
+      {{#subtypes}}
+          this.subAdapter{{@index}} = ctx.adapter({{.}}.class);
+      {{/subtypes}}
+        }
+
+        @Override
+        public boolean validate({{shortType}} value, ValidationRequest request, String field) {
+      {{validation}}
+        }
+      }
+      """)
+  public record SubTemplate(
+      String packageName,
+      Set<String> imports,
+      String shortName,
+      String shortType,
+      List<String> subtypes,
+      String validation) {
+    String render() {
+      return SubTemplateRenderer.of().execute(this);
+    }
+  }
+
+  @JStache(
+      template =
+          """
+        {{#subtypes}}
+        if (value instanceof {{.}} val) {
+          return subAdapter{{@index}}.validate(val, request, field);
+        }
+        {{/subtypes}}
+        return true;
+    """)
+  public record IfValidation(List<String> subtypes) {
+    String render() {
+      return IfValidationRenderer.of().execute(this);
+    }
+  }
+
+  @JStache(
+      template =
+          """
+    return switch(value) {
+      case null -> true;
+    {{#subtypes}}
+      case {{.}} val -> subAdapter{{@index}}.validate(val, request, field);
+    {{/subtypes}}
+    {{^sealed}}
+      default -> true;
+    {{/sealed}}
+    };
+""")
+  public record SwitchValidation(List<String> subtypes, boolean sealed) {
+    String render() {
+      return SwitchValidationRenderer.of().execute(this);
+    }
+  }
+}

--- a/validator-generator/src/main/java/io/avaje/validation/generator/SubTypeWriter.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/SubTypeWriter.java
@@ -55,9 +55,8 @@ public class SubTypeWriter {
       var validation =
           APContext.jdkVersion() > 17
               ? new SwitchValidation(
-                      subtypeStrings, element.getModifiers().contains(Modifier.SEALED))
-                  .render()
-              : new IfValidation(subtypeStrings).render();
+                  subtypeStrings, element.getModifiers().contains(Modifier.SEALED))
+              : new IfValidation(subtypeStrings);
 
       var template =
           new SubTemplate(
@@ -99,7 +98,7 @@ public class SubTypeWriter {
 
         @Override
         public boolean validate({{shortType}} value, ValidationRequest request, String field) {
-      {{validation}}
+      {{validation.render}}
         }
       }
       """)
@@ -109,7 +108,7 @@ public class SubTypeWriter {
       String shortName,
       String shortType,
       List<String> subtypes,
-      String validation) {
+      Template validation) {
     String render() {
       return SubTemplateRenderer.of().execute(this);
     }
@@ -125,8 +124,9 @@ public class SubTypeWriter {
         {{/subtypes}}
         return true;
     """)
-  public record IfValidation(List<String> subtypes) {
-    String render() {
+  public record IfValidation(List<String> subtypes) implements Template {
+    @Override
+    public String render() {
       return IfValidationRenderer.of().execute(this);
     }
   }
@@ -144,9 +144,14 @@ public class SubTypeWriter {
     {{/sealed}}
     };
 """)
-  public record SwitchValidation(List<String> subtypes, boolean sealed) {
-    String render() {
+  public record SwitchValidation(List<String> subtypes, boolean sealed) implements Template {
+    @Override
+    public String render() {
       return SwitchValidationRenderer.of().execute(this);
     }
+  }
+
+  interface Template {
+    String render();
   }
 }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ValidationProcessor.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ValidationProcessor.java
@@ -42,7 +42,7 @@ import static io.avaje.validation.generator.APContext.*;
   JavaxConstraintPrism.PRISM_TYPE,
   CrossParamConstraintPrism.PRISM_TYPE,
   ValidMethodPrism.PRISM_TYPE,
-  SubTypesPrism.PRISM_TYPE,
+  ValidSubTypesPrism.PRISM_TYPE,
   "io.avaje.spi.ServiceProvider"
 })
 public final class ValidationProcessor extends AbstractProcessor {
@@ -118,7 +118,7 @@ public final class ValidationProcessor extends AbstractProcessor {
     getElements(round, MixInPrism.PRISM_TYPE).ifPresent(this::writeAdaptersForMixInTypes);
     getElements(round, ImportValidPojoPrism.PRISM_TYPE).ifPresent(this::writeAdaptersForImported);
     getElements(round, "io.avaje.spi.ServiceProvider").ifPresent(this::registerSPI);
-    getElements(round, SubTypesPrism.PRISM_TYPE).ifPresent(this::writeSubTypeAdaptersForImported);
+    getElements(round, ValidSubTypesPrism.PRISM_TYPE).ifPresent(this::writeSubTypeAdaptersForImported);
 
     initialiseComponent();
     cascadeTypes();
@@ -211,10 +211,10 @@ public final class ValidationProcessor extends AbstractProcessor {
         || sourceTypes.contains(type);
   }
 
-  /** Elements that have a {@code @SubTypes} annotation. */
+  /** Elements that have a {@code @ValidSubTypes} annotation. */
   private void writeSubTypeAdaptersForImported(Set<? extends Element> subtypeElements) {
     for (final var element : ElementFilter.typesIn(subtypeElements)) {
-      var prism = SubTypesPrism.getInstanceOn(element);
+      var prism = ValidSubTypesPrism.getInstanceOn(element);
       var subtypes = new ArrayList<>(prism.value());
       subtypes.addAll(element.getPermittedSubclasses());
 

--- a/validator-generator/src/main/java/io/avaje/validation/generator/package-info.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/package-info.java
@@ -1,5 +1,6 @@
 @GeneratePrism(io.avaje.validation.adapter.ConstraintAdapter.class)
 @GeneratePrism(io.avaje.validation.ImportValidPojo.class)
+@GeneratePrism(io.avaje.validation.SubTypes.class)
 @GeneratePrism(io.avaje.validation.spi.MetaData.class)
 @GeneratePrism(io.avaje.validation.spi.MetaData.ValidFactory.class)
 @GeneratePrism(io.avaje.validation.spi.MetaData.AnnotationFactory.class)

--- a/validator-generator/src/main/java/io/avaje/validation/generator/package-info.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/package-info.java
@@ -1,6 +1,6 @@
 @GeneratePrism(io.avaje.validation.adapter.ConstraintAdapter.class)
 @GeneratePrism(io.avaje.validation.ImportValidPojo.class)
-@GeneratePrism(io.avaje.validation.SubTypes.class)
+@GeneratePrism(io.avaje.validation.ValidSubTypes.class)
 @GeneratePrism(io.avaje.validation.spi.MetaData.class)
 @GeneratePrism(io.avaje.validation.spi.MetaData.ValidFactory.class)
 @GeneratePrism(io.avaje.validation.spi.MetaData.AnnotationFactory.class)

--- a/validator-generator/src/main/java/module-info.java
+++ b/validator-generator/src/main/java/module-info.java
@@ -1,3 +1,7 @@
+import io.jstach.jstache.JStacheConfig;
+import io.jstach.jstache.JStacheType;
+
+@JStacheConfig(type = JStacheType.STACHE)
 module io.avaje.validation.generator {
 
   requires java.compiler;
@@ -5,6 +9,7 @@ module io.avaje.validation.generator {
   requires static io.avaje.prism;
   requires static io.avaje.http.api;
   requires static io.avaje.validation.contraints;
+  requires static io.jstach.jstache;
   requires static java.validation;
   requires static jakarta.validation;
 

--- a/validator-generator/src/test/java/io/avaje/validation/generator/ValidatorProcessorTest.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/ValidatorProcessorTest.java
@@ -62,7 +62,7 @@ class ValidatorProcessorTest {
 
     final CompilationTask task =
         compiler.getTask(
-            new PrintWriter(System.out), null, null, Arrays.asList("--release=17"), null, files);
+            new PrintWriter(System.out), null, null, Arrays.asList("--release=" + Integer.getInteger("java.specification.version")), null, files);
     task.setProcessors(Arrays.asList(new ValidationProcessor()));
 
     assertThat(task.call()).isTrue();

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/subtypes/ByIdSelector.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/subtypes/ByIdSelector.java
@@ -1,0 +1,20 @@
+package io.avaje.validation.generator.models.valid.subtypes;
+
+import java.util.List;
+import java.util.UUID;
+
+import io.avaje.validation.constraints.NotEmpty;
+
+public final class ByIdSelector implements EntitySelector {
+
+  @NotEmpty
+  private List<UUID> ids;
+
+  public void setIds(List<UUID> ids) {
+    this.ids = ids;
+  }
+
+  public List<UUID> getIds() {
+    return ids;
+  }
+}

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/subtypes/ByQuerySelector.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/subtypes/ByQuerySelector.java
@@ -1,0 +1,16 @@
+package io.avaje.validation.generator.models.valid.subtypes;
+
+import javax.validation.constraints.NotBlank;
+
+public final class ByQuerySelector implements EntitySelector {
+
+  @NotBlank private String query;
+
+  public void setQuery(String query) {
+    this.query = query;
+  }
+
+  public String getQuery() {
+    return query;
+  }
+}

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/subtypes/EntitySelector.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/subtypes/EntitySelector.java
@@ -1,0 +1,6 @@
+package io.avaje.validation.generator.models.valid.subtypes;
+
+import io.avaje.validation.SubTypes;
+
+@SubTypes({ByQuerySelector.class, ByIdSelector.class})
+public interface EntitySelector {}

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/subtypes/EntitySelector.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/subtypes/EntitySelector.java
@@ -1,6 +1,6 @@
 package io.avaje.validation.generator.models.valid.subtypes;
 
-import io.avaje.validation.SubTypes;
+import io.avaje.validation.ValidSubTypes;
 
-@SubTypes({ByQuerySelector.class, ByIdSelector.class})
+@ValidSubTypes({ByQuerySelector.class, ByIdSelector.class})
 public interface EntitySelector {}

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/subtypes/sealed/ByIdSelectorSealed.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/subtypes/sealed/ByIdSelectorSealed.java
@@ -1,0 +1,20 @@
+package io.avaje.validation.generator.models.valid.subtypes.sealed;
+
+import java.util.List;
+import java.util.UUID;
+
+import io.avaje.validation.constraints.NotEmpty;
+
+public final class ByIdSelectorSealed implements SealedEntitySelector {
+
+  @NotEmpty
+  private List<UUID> ids;
+
+  public void setIds(List<UUID> ids) {
+    this.ids = ids;
+  }
+
+  public List<UUID> getIds() {
+    return ids;
+  }
+}

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/subtypes/sealed/ByQuerySelectorSealed.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/subtypes/sealed/ByQuerySelectorSealed.java
@@ -1,0 +1,16 @@
+package io.avaje.validation.generator.models.valid.subtypes.sealed;
+
+import javax.validation.constraints.NotBlank;
+
+public final class ByQuerySelectorSealed implements SealedEntitySelector {
+
+  @NotBlank private String query;
+
+  public void setQuery(String query) {
+    this.query = query;
+  }
+
+  public String getQuery() {
+    return query;
+  }
+}

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/subtypes/sealed/SealedEntitySelector.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/subtypes/sealed/SealedEntitySelector.java
@@ -3,11 +3,11 @@ package io.avaje.validation.generator.models.valid.subtypes.sealed;
 import java.util.List;
 import java.util.UUID;
 
-import io.avaje.validation.SubTypes;
+import io.avaje.validation.ValidSubTypes;
 import io.avaje.validation.constraints.NotEmpty;
 import io.avaje.validation.generator.models.valid.subtypes.sealed.SealedEntitySelector.NestedSealed;
 
-@SubTypes
+@ValidSubTypes
 public sealed interface SealedEntitySelector
     permits ByQuerySelectorSealed, ByIdSelectorSealed, NestedSealed {
 

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/subtypes/sealed/SealedEntitySelector.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/subtypes/sealed/SealedEntitySelector.java
@@ -1,0 +1,15 @@
+package io.avaje.validation.generator.models.valid.subtypes.sealed;
+
+import java.util.List;
+import java.util.UUID;
+
+import io.avaje.validation.SubTypes;
+import io.avaje.validation.constraints.NotEmpty;
+import io.avaje.validation.generator.models.valid.subtypes.sealed.SealedEntitySelector.NestedSealed;
+
+@SubTypes
+public sealed interface SealedEntitySelector
+    permits ByQuerySelectorSealed, ByIdSelectorSealed, NestedSealed {
+
+  public final record NestedSealed(@NotEmpty List<UUID> ids) implements SealedEntitySelector {}
+}

--- a/validator/src/main/java/io/avaje/validation/SubTypes.java
+++ b/validator/src/main/java/io/avaje/validation/SubTypes.java
@@ -1,0 +1,6 @@
+package io.avaje.validation;
+
+public @interface SubTypes {
+
+  Class<?>[] value() default {};
+}

--- a/validator/src/main/java/io/avaje/validation/SubTypes.java
+++ b/validator/src/main/java/io/avaje/validation/SubTypes.java
@@ -1,6 +1,44 @@
 package io.avaje.validation;
 
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Specify the subtypes that a given type can be represented as.
+ * <p>
+ * This is used on an interface type, abstract type or type with inheritance
+ * to indicate all the concrete subtypes that can represent the type.
+ * <p>
+ * In the example below the abstract Vehicle type has 2 concrete subtypes
+ * of Car and Truck that can represent the type.
+ *
+ * <pre>{@code
+ *
+ *   @SubTypes(Car.class, Truck.class)
+ *   public abstract class Vehicle {
+ *    ...
+ *
+ * }</pre>
+ *
+ *  * <p>
+ * In the example below the abstract Vehicle type has 2 concrete subtypes
+ * of Car and Truck that can represent the type.
+ *
+ * <pre>{@code
+ *
+ *   @SubTypes(Car.class, Truck.class)
+ *   public abstract class Vehicle {
+ *    ...
+ *
+ * }</pre>
+ */
+@Target(TYPE)
+@Retention(SOURCE)
 public @interface SubTypes {
 
+  /** Subclasses of the current type. Not needed for sealed classes */
   Class<?>[] value() default {};
 }

--- a/validator/src/main/java/io/avaje/validation/ValidSubTypes.java
+++ b/validator/src/main/java/io/avaje/validation/ValidSubTypes.java
@@ -17,7 +17,7 @@ import java.lang.annotation.Target;
  *
  * <pre>{@code
  *
- *   @SubTypes(Car.class, Truck.class)
+ *   @ValidSubTypes(Car.class, Truck.class)
  *   public abstract class Vehicle {
  *    ...
  *
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  *
  * <pre>{@code
  *
- *   @SubTypes(Car.class, Truck.class)
+ *   @ValidSubTypes(Car.class, Truck.class)
  *   public abstract class Vehicle {
  *    ...
  *
@@ -37,7 +37,7 @@ import java.lang.annotation.Target;
  */
 @Target(TYPE)
 @Retention(SOURCE)
-public @interface SubTypes {
+public @interface ValidSubTypes {
 
   /** Subclasses of the current type. Not needed for sealed classes */
   Class<?>[] value() default {};


### PR DESCRIPTION
- adds a new annotation to extract subtype info from a class
- will generate a validator that uses `instanceof` (17) or pattern matching switch (21+) to redirect to the correct validator
- add Jstachio (compile-time templating is pretty handy)

Given
```java
@SubTypes({ByQuerySelector.class, ByIdSelector.class})
public interface EntitySelector {}
```

The following is generated
```java
@Generated("avaje-validation-generator")
public class EntitySelectorValidationAdapter implements ValidationAdapter<EntitySelector> {

  private final ValidationAdapter<ByQuerySelector> subAdapter0;
  private final ValidationAdapter<ByIdSelector> subAdapter1;

  public EntitySelectorValidationAdapter(ValidationContext ctx) {
    this.subAdapter0 = ctx.adapter(ByQuerySelector.class);
    this.subAdapter1 = ctx.adapter(ByIdSelector.class);
  }

  @Override
  public boolean validate(EntitySelector value, ValidationRequest request, String field) {
    return switch(value) {
      case null -> true;
      case ByQuerySelector val -> subAdapter0.validate(val, request, field);
      case ByIdSelector val -> subAdapter1.validate(val, request, field);
      default -> true;
    };

  }
}
```



Fixes #279