### PR TITLE
Fix JDT Errors and Fix for duplicate generated fields

### DIFF
--- a/validator-generator/src/main/java/io/avaje/validation/generator/AdapterName.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/AdapterName.java
@@ -9,7 +9,7 @@ final class AdapterName {
   final String fullName;
 
   AdapterName(TypeElement origin) {
-    String originPackage = APContext.elements().getPackageOf(origin).toString();
+    String originPackage = APContext.elements().getPackageOf(origin).getQualifiedName().toString();
     var name = shortName(origin);
     shortName = name.substring(0, name.length() - 1);
     if ("".equals(originPackage)) {

--- a/validator-generator/src/main/java/io/avaje/validation/generator/AnnotationUtil.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/AnnotationUtil.java
@@ -161,8 +161,8 @@ final class AnnotationUtil {
   private AnnotationUtil() {}
 
   static String annotationAttributeMap(AnnotationMirror annotationMirror, Element target) {
-    final Element element = annotationMirror.getAnnotationType().asElement();
-    final Handler handler = handlers.get(element.toString());
+    final var element = APContext.asTypeElement(annotationMirror.getAnnotationType());
+    final Handler handler = handlers.get(element.getQualifiedName().toString());
     return Objects.requireNonNullElse(handler, defaultHandler)
         .attributes(annotationMirror, element, target);
   }
@@ -381,7 +381,7 @@ final class AnnotationUtil {
     @Override
     public boolean isSupported(Element target, String _type) {
       boolean isMetaConstraint = hasMetaConstraintAnnotation(target);
-      return isMetaConstraint || (allowUnknown && _type == null) || (_type != null && supportedTypes.contains(_type));
+      return isMetaConstraint || allowUnknown && _type == null || _type != null && supportedTypes.contains(_type);
     }
   }
 
@@ -463,7 +463,7 @@ final class AnnotationUtil {
     @Override
     String messageKey(AnnotationValue defaultValue) {
       final AnnotationValue inclusiveValue = memberValue("inclusive");
-      final boolean inclusive = (inclusiveValue == null || "true".equals(inclusiveValue.toString()));
+      final boolean inclusive = inclusiveValue == null || "true".equals(inclusiveValue.toString());
       String messageKey = super.messageKey(defaultValue);
       if (!inclusive) {
         messageKey = messageKey.replace(".message", ".exclusive.message");

--- a/validator-generator/src/main/java/io/avaje/validation/generator/SimpleParamBeanWriter.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/SimpleParamBeanWriter.java
@@ -20,18 +20,14 @@ final class SimpleParamBeanWriter {
   SimpleParamBeanWriter(ValidMethodReader beanReader) {
     this.beanReader = beanReader;
     final var method = beanReader.getBeanType();
-    this.adapterPackage =
-        ProcessorUtils.packageOf(
-            ((TypeElement) method.getEnclosingElement()).getQualifiedName().toString());
-    this.adapterFullName =
-        adapterPackage
-            + "."
-            + method
-                .getSimpleName()
-                .toString()
-                .transform(str -> str.substring(0, 1).toUpperCase() + str.substring(1))
-            + "ParamProvider";
-
+    this.adapterPackage = ProcessorUtils.packageOf(((TypeElement) method.getEnclosingElement()).getQualifiedName().toString());
+    this.adapterFullName = adapterPackage
+      + "."
+      + method
+      .getSimpleName()
+      .toString()
+      .transform(str -> str.substring(0, 1).toUpperCase() + str.substring(1))
+      + "ParamProvider";
     this.adapterShortName = Util.shortName(adapterFullName);
   }
 

--- a/validator-generator/src/main/java/io/avaje/validation/generator/SimpleParamBeanWriter.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/SimpleParamBeanWriter.java
@@ -6,6 +6,7 @@ import static io.avaje.validation.generator.ProcessingContext.diAnnotation;
 import java.io.IOException;
 import java.io.Writer;
 
+import javax.lang.model.element.TypeElement;
 import javax.tools.JavaFileObject;
 
 final class SimpleParamBeanWriter {
@@ -19,14 +20,17 @@ final class SimpleParamBeanWriter {
   SimpleParamBeanWriter(ValidMethodReader beanReader) {
     this.beanReader = beanReader;
     final var method = beanReader.getBeanType();
-    this.adapterPackage = ProcessorUtils.packageOf(method.getEnclosingElement().asType().toString());
-    this.adapterFullName = adapterPackage
-      + "."
-      + method
-      .getSimpleName()
-      .toString()
-      .transform(str -> str.substring(0, 1).toUpperCase() + str.substring(1))
-      + "ParamProvider";
+    this.adapterPackage =
+        ProcessorUtils.packageOf(
+            ((TypeElement) method.getEnclosingElement()).getQualifiedName().toString());
+    this.adapterFullName =
+        adapterPackage
+            + "."
+            + method
+                .getSimpleName()
+                .toString()
+                .transform(str -> str.substring(0, 1).toUpperCase() + str.substring(1))
+            + "ParamProvider";
 
     this.adapterShortName = Util.shortName(adapterFullName);
   }

--- a/validator-generator/src/main/java/io/avaje/validation/generator/TypeReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/TypeReader.java
@@ -1,8 +1,8 @@
 package io.avaje.validation.generator;
 
 import static io.avaje.validation.generator.APContext.asTypeElement;
-import static io.avaje.validation.generator.APContext.logNote;
 import static io.avaje.validation.generator.APContext.logError;
+import static io.avaje.validation.generator.APContext.logNote;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -83,8 +83,9 @@ final class TypeReader {
     }
 
     for (final FieldReader localField : localFields) {
-      allFields.add(localField);
-      allFieldMap.put(localField.fieldName(), localField);
+      if (allFieldMap.put(localField.fieldName(), localField) == null) {
+        allFields.add(localField);
+      }
     }
   }
 


### PR DESCRIPTION
- It turns out using `toString` on some elements doesn't print the right thing with some compilers
- prevents duplicate field generation