### PR TITLE
skip class level NonNull

### DIFF
--- a/validator-generator/src/main/java/io/avaje/validation/generator/FieldReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/FieldReader.java
@@ -45,7 +45,12 @@ final class FieldReader {
     this.optionalValidation = Util.isNullable(element);
     this.classLevel = classLevel;
     if (classLevel) {
-      elementAnnotations.annotations().removeIf(e -> e.getKey().shortType().contains("NonNull"));
+      elementAnnotations
+          .annotations()
+          .removeIf(
+              e ->
+                  "NonNull".equals(e.getKey().shortType())
+                      || "NonNull".equals(e.getKey().shortType()));
     }
   }
 

--- a/validator-generator/src/main/java/io/avaje/validation/generator/FieldReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/FieldReader.java
@@ -50,7 +50,7 @@ final class FieldReader {
           .removeIf(
               e ->
                   "NonNull".equals(e.getKey().shortType())
-                      || "NonNull".equals(e.getKey().shortType()));
+                      || "NotNull".equals(e.getKey().shortType()));
     }
   }
 

--- a/validator-generator/src/main/java/io/avaje/validation/generator/FieldReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/FieldReader.java
@@ -44,6 +44,9 @@ final class FieldReader {
     this.adapterFieldName = initShortName();
     this.optionalValidation = Util.isNullable(element);
     this.classLevel = classLevel;
+    if (classLevel) {
+      elementAnnotations.annotations().removeIf(e -> e.getKey().shortType().contains("NonNull"));
+    }
   }
 
   FieldReader(TypeElement baseType, TypeElement mixInType, List<String> genericTypeParams) {


### PR DESCRIPTION
Class level validation runs only if the object isn't null, so this removes not null class constraints.