### PR TITLE
Return the same default instance if unchanged

### DIFF
--- a/validator/src/main/java/io/avaje/validation/core/DValidator.java
+++ b/validator/src/main/java/io/avaje/validation/core/DValidator.java
@@ -180,8 +180,8 @@ final class DValidator implements Validator, ValidationContext {
   /** Implementation of Validator.Builder. */
   static final class DBuilder implements Validator.Builder {
 
-    private static Validator DEFAULT = Validator.builder().build();
-    private static Supplier<Clock> DEFAULT_CLOCK = Clock::systemDefaultZone;
+    private static final Validator DEFAULT = Validator.builder().build();
+    private static final Supplier<Clock> DEFAULT_CLOCK = Clock::systemDefaultZone;
 
     private final List<AdapterFactory> factories = new ArrayList<>();
     private final List<AnnotationFactory> afactories = new ArrayList<>();

--- a/validator/src/test/java/io/avaje/validation/core/TestBuilder.java
+++ b/validator/src/test/java/io/avaje/validation/core/TestBuilder.java
@@ -1,0 +1,22 @@
+package io.avaje.validation.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.validation.Validator;
+
+class TestBuilder {
+
+  @Test
+  void defaultBuilderReturnSameInstance() {
+
+    assertThat(Validator.builder().build()).isSameAs(Validator.builder().build());
+  }
+
+  @Test
+  void changedBuilderNotSame() {
+
+    assertThat(Validator.builder().failFast(true).build()).isNotSameAs(Validator.builder().build());
+  }
+}


### PR DESCRIPTION
Why create a separate instance that needs its own caching of adapters, resource bundle lookups, etc?

- Now the builder will return the same validator instance when no changes in the builder are detected.

Essentially, this change causes the same `Validator` instance to be returned by the statement `Validator.builder().build()`