### PR TITLE
Reformat & correct the JavaDoc of all constraints

### DIFF
--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/AssertFalse.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/AssertFalse.java
@@ -11,9 +11,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * The annotated element must be false. Supported types are {@code boolean} and {@code Boolean}.
- *
- * <p>{@code null} elements are considered valid.
+ * The annotated element must be false.
+ * Supported types are {@code boolean} and {@code Boolean}.
+ * <p>
+ * {@code null} elements are considered valid.
  *
  * @author Emmanuel Bernard
  */

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/AssertTrue.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/AssertTrue.java
@@ -11,9 +11,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * The annotated element must be true. Supported types are {@code boolean} and {@code Boolean}.
- *
- * <p>{@code null} elements are considered valid.
+ * The annotated element must be true.
+ * Supported types are {@code boolean} and {@code Boolean}.
+ * <p>
+ * {@code null} elements are considered valid.
  *
  * @author Emmanuel Bernard
  */

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Constraint.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Constraint.java
@@ -7,7 +7,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * Marks an annotation as a Constraint class. Only annotations marked with Constraint are composable
+ * Marks an annotation as a constraint class.
+ * Only annotations marked with {@code @Constraint} are composable.
  */
 @Retention(CLASS)
 @Target({ANNOTATION_TYPE})

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/DecimalMax.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/DecimalMax.java
@@ -14,20 +14,18 @@ import java.lang.annotation.Target;
 /**
  * The annotated element must be a number whose value must be lower or equal to the specified
  * maximum.
- *
- * <p>Supported types are:
- *
+ * <p>
+ * Supported types are:
  * <ul>
  *   <li>{@code BigDecimal}
  *   <li>{@code BigInteger}
  *   <li>{@code CharSequence}
  *   <li>{@code byte}, {@code short}, {@code int}, {@code long}, and their respective wrappers
  * </ul>
- *
  * Note that {@code double} and {@code float} are not supported due to rounding errors (some
  * providers might provide some approximative support).
- *
- * <p>{@code null} elements are considered valid.
+ * <p>
+ * {@code null} elements are considered valid.
  *
  * @author Emmanuel Bernard
  */
@@ -52,8 +50,8 @@ public @interface DecimalMax {
   /**
    * Specifies whether the specified maximum is inclusive or exclusive. By default, it is inclusive.
    *
-   * @return {@code true} if the value must be lower or equal to the specified maximum, {@code
-   *     false} if the value must be lower
+   * @return {@code true} if the value must be lower or equal to the specified maximum,
+   *         {@code false} if the value must be lower
    * @since 1.1
    */
   boolean inclusive() default true;

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/DecimalMin.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/DecimalMin.java
@@ -20,20 +20,18 @@ import java.lang.annotation.Target;
 /**
  * The annotated element must be a number whose value must be higher or equal to the specified
  * minimum.
- *
- * <p>Supported types are:
- *
+ * <p>
+ * Supported types are:
  * <ul>
  *   <li>{@code BigDecimal}
  *   <li>{@code BigInteger}
  *   <li>{@code CharSequence}
  *   <li>{@code byte}, {@code short}, {@code int}, {@code long}, and their respective wrappers
  * </ul>
- *
  * Note that {@code double} and {@code float} are not supported due to rounding errors (some
  * providers might provide some approximative support).
- *
- * <p>{@code null} elements are considered valid.
+ * <p>
+ * {@code null} elements are considered valid.
  *
  * @author Emmanuel Bernard
  */
@@ -58,8 +56,8 @@ public @interface DecimalMin {
   /**
    * Specifies whether the specified maximum is inclusive or exclusive. By default, it is inclusive.
    *
-   * @return {@code true} if the value must be lower or equal to the specified maximum, {@code
-   *     false} if the value must be lower
+   * @return {@code true} if the value must be lower or equal to the specified maximum,
+   *         {@code false} if the value must be lower
    * @since 1.1
    */
   boolean inclusive() default true;

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Digits.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Digits.java
@@ -15,17 +15,16 @@ import java.lang.annotation.Target;
 
 /**
  * The annotated element must be a number within accepted range.
- *
- * <p>Supported types are:
- *
+ * <p>
+ * Supported types are:
  * <ul>
  *   <li>{@code BigDecimal}
  *   <li>{@code BigInteger}
  *   <li>{@code CharSequence}
  *   <li>{@code byte}, {@code short}, {@code int}, {@code long}, and their respective wrapper types
  * </ul>
- *
- * <p>{@code null} elements are considered valid.
+ * <p>
+ * {@code null} elements are considered valid.
  *
  * @author Emmanuel Bernard
  */
@@ -38,10 +37,17 @@ public @interface Digits {
 
   Class<?>[] groups() default {};
 
+  /** @return maximum number of integral digits accepted for this number */
   int integer();
 
+  /** @return maximum number of fractional digits accepted for this number */
   int fraction() default 0;
 
+	/**
+	 * Defines several {@link Digits} annotations on the same element.
+	 *
+	 * @see Digits
+	 */
   @Target({ElementType.METHOD, ElementType.FIELD})
   @Retention(RetentionPolicy.RUNTIME)
   @Documented

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Email.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Email.java
@@ -13,10 +13,10 @@ import java.lang.annotation.Target;
 
 /**
  * The string has to be a well-formed email address. Exact semantics of what makes up a valid email
- * address are left to the provided Email Annotation ValidationAdapter providers. Accepts {@code
- * CharSequence}.
- *
- * <p>{@code null} elements are considered valid.
+ * address are left to the provided Email Annotation ValidationAdapter providers.
+ * <p>
+ * Accepts {@code CharSequence}.
+ * {@code null} elements are considered valid.
  */
 @Constraint
 @Documented

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Future.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Future.java
@@ -13,13 +13,12 @@ import java.lang.annotation.Target;
 
 /**
  * The annotated element must be an instant, date or time in the future.
- *
- * <p><i>Now</i> is defined by the {@link Clock} Supplier attached to the {@link Validator}. The
+ * <p>
+ * <i>Now</i> is defined by the {@code Clock} Supplier attached to the {@code Validator}. The
  * default clock defines the current time according to the virtual machine, applying the current
  * default time zone if needed.
- *
- * <p>Supported types are:
- *
+ * <p>
+ * Supported types are:
  * <ul>
  *   <li>{@code java.util.Date}
  *   <li>{@code java.util.Calendar}
@@ -34,8 +33,8 @@ import java.lang.annotation.Target;
  *   <li>{@code java.time.YearMonth}
  *   <li>{@code java.time.ZonedDateTime}
  * </ul>
- *
- * <p>{@code null} elements are considered valid.
+ * <p>
+ * {@code null} elements are considered valid.
  */
 @Constraint
 @Documented

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/FutureOrPresent.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/FutureOrPresent.java
@@ -13,16 +13,15 @@ import java.lang.annotation.Target;
 
 /**
  * The annotated element must be an instant, date or time in the present or in the future.
- *
- * <p><i>Now</i> is defined by the {@link Clock} Supplier attached to the {@link Validator}. The
+ * <p>
+ * <i>Now</i> is defined by the {@code Clock} Supplier attached to the {@code Validator}. The
  * default clock defines the current time according to the virtual machine, applying the current
  * default time zone if needed.
- *
- * <p>The notion of present here is defined relatively to the type on which the constraint is used.
- * For instance, if the constraint is on a {@link Year}, present would mean the whole current year.
- *
- * <p>Supported types are:
- *
+ * <p>
+ * The notion of present here is defined relatively to the type on which the constraint is used.
+ * For instance, if the constraint is on a {@code Year}, present would mean the whole current year.
+ * <p>
+ * Supported types are:
  * <ul>
  *   <li>{@code java.util.Date}
  *   <li>{@code java.util.Calendar}
@@ -37,8 +36,8 @@ import java.lang.annotation.Target;
  *   <li>{@code java.time.YearMonth}
  *   <li>{@code java.time.ZonedDateTime}
  * </ul>
- *
- * <p>{@code null} elements are considered valid.
+ * <p>
+ * {@code null} elements are considered valid.
  */
 @Constraint
 @Documented

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Length.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Length.java
@@ -6,8 +6,8 @@ import static java.lang.annotation.ElementType.*;
 
 /**
  * The annotated string length must be between the specified boundaries (included).
- *
- * <p>Supported types are:
+ * <p>
+ * Supported types are:
  * <ul>
  *   <li>{@code CharSequence} (length of character sequence is evaluated)
  *   <li>{@code String} (length of character sequence is evaluated)
@@ -23,10 +23,17 @@ public @interface Length {
 
   Class<?>[] groups() default {};
 
+  /** @return size the string must be higher or equal to */
   int min() default 0;
 
+	/** @return size the string must be lower or equal to */
   int max() default Integer.MAX_VALUE;
 
+  /**
+	 * Defines several {@link Length} annotations on the same element.
+	 *
+	 * @see Length
+	 */
   @Target({ElementType.METHOD, ElementType.FIELD})
   @Retention(RetentionPolicy.RUNTIME)
   @Documented

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Max.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Max.java
@@ -14,21 +14,20 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * The annotated element must be a number whose value must be lower or equal to the specified
- * maximum.
- *
- * <p>Supported types are:
- *
+ * The annotated element must be a number whose value must be lower or
+ * equal to the specified maximum.
+ * <p>
+ * Supported types are:
  * <ul>
- *   <li>{@code BigDecimal}
- *   <li>{@code BigInteger}
- *   <li>{@code byte}, {@code short}, {@code int}, {@code long}, and their respective wrappers
+ *     <li>{@code BigDecimal}</li>
+ *     <li>{@code BigInteger}</li>
+ *     <li>{@code byte}, {@code short}, {@code int}, {@code long}, and their respective
+ *     wrappers</li>
  * </ul>
- *
- * Note that {@code double} and {@code float} are not supported due to rounding errors (some
- * providers might provide some approximative support).
- *
- * <p>{@code null} elements are considered valid.
+ * Note that {@code double} and {@code float} are not supported due to rounding errors
+ * (some providers might provide some approximative support).
+ * <p>
+ * {@code null} elements are considered valid.
  *
  * @author Emmanuel Bernard
  */
@@ -41,8 +40,14 @@ public @interface Max {
 
   Class<?>[] groups() default {};
 
+	/** @return value the element must be lower or equal to */
   long value();
 
+	/**
+	 * Defines several {@link Max} annotations on the same element.
+	 *
+	 * @see Max
+	 */
   @Target({ElementType.METHOD, ElementType.FIELD})
   @Retention(RetentionPolicy.RUNTIME)
   @Documented

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Min.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Min.java
@@ -14,21 +14,20 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * The annotated element must be a number whose value must be higher or equal to the specified
- * minimum.
- *
- * <p>Supported types are:
- *
+ * The annotated element must be a number whose value must be higher or
+ * equal to the specified minimum.
+ * <p>
+ * Supported types are:
  * <ul>
- *   <li>{@code BigDecimal}
- *   <li>{@code BigInteger}
- *   <li>{@code byte}, {@code short}, {@code int}, {@code long}, and their respective wrappers
+ *     <li>{@code BigDecimal}</li>
+ *     <li>{@code BigInteger}</li>
+ *     <li>{@code byte}, {@code short}, {@code int}, {@code long}, and their respective
+ *     wrappers</li>
  * </ul>
- *
- * Note that {@code double} and {@code float} are not supported due to rounding errors (some
- * providers might provide some approximative support).
- *
- * <p>{@code null} elements are considered valid.
+ * Note that {@code double} and {@code float} are not supported due to rounding errors
+ * (some providers might provide some approximative support).
+ * <p>
+ * {@code null} elements are considered valid.
  *
  * @author Emmanuel Bernard
  */
@@ -41,8 +40,14 @@ public @interface Min {
 
   Class<?>[] groups() default {};
 
+	/** @return value the element must be higher or equal to */
   long value();
 
+	/**
+	 * Defines several {@link Min} annotations on the same element.
+	 *
+	 * @see Min
+	 */
   @Target({ElementType.METHOD, ElementType.FIELD})
   @Retention(RetentionPolicy.RUNTIME)
   @Documented

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Negative.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Negative.java
@@ -12,19 +12,18 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * The annotated element must be a strictly negative number (i.e. 0 is considered as an invalid
- * value).
- *
- * <p>Supported types are:
- *
+ * The annotated element must be a strictly negative number (i.e. 0 is considered as an
+ * invalid value).
+ * <p>
+ * Supported types are:
  * <ul>
- *   <li>{@code BigDecimal}
- *   <li>{@code BigInteger}
- *   <li>{@code byte}, {@code short}, {@code int}, {@code long}, {@code float}, {@code double} and
- *       their respective wrappers
+ *     <li>{@code BigDecimal}</li>
+ *     <li>{@code BigInteger}</li>
+ *     <li>{@code byte}, {@code short}, {@code int}, {@code long}, {@code float},
+ *     {@code double} and their respective wrappers</li>
  * </ul>
- *
- * <p>{@code null} elements are considered valid.
+ * <p>
+ * {@code null} elements are considered valid.
  *
  * @author Gunnar Morling
  */

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/NegativeOrZero.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/NegativeOrZero.java
@@ -13,17 +13,16 @@ import java.lang.annotation.Target;
 
 /**
  * The annotated element must be a negative number or 0.
- *
- * <p>Supported types are:
- *
+ * <p>
+ * Supported types are:
  * <ul>
- *   <li>{@code BigDecimal}
- *   <li>{@code BigInteger}
- *   <li>{@code byte}, {@code short}, {@code int}, {@code long}, {@code float}, {@code double} and
- *       their respective wrappers
+ *     <li>{@code BigDecimal}</li>
+ *     <li>{@code BigInteger}</li>
+ *     <li>{@code byte}, {@code short}, {@code int}, {@code long}, {@code float},
+ *     {@code double} and their respective wrappers</li>
  * </ul>
- *
- * <p>{@code null} elements are considered valid.
+ * <p>
+ * {@code null} elements are considered valid.
  *
  * @author Gunnar Morling
  */

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/NotBlank.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/NotBlank.java
@@ -12,8 +12,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * The annotated element must not be {@code null} and must contain at least one non-whitespace
- * character. Accepts {@code CharSequence}.
+ * The annotated element must not be {@code null} and must contain at least one
+ * non-whitespace character. Accepts {@code CharSequence}.
  *
  * @author Hardy Ferentschik
  * @see Character#isWhitespace(char)

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/NotEmpty.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/NotEmpty.java
@@ -12,11 +12,17 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * The annotated element must not be {@code null} and must contain at least one non-whitespace
- * character. Accepts {@code CharSequence}.
+ * The annotated element must not be {@code null} nor empty.
+ * <p>
+ * Supported types are:
+ * <ul>
+ * <li>{@code CharSequence} (length of character sequence is evaluated)</li>
+ * <li>{@code Collection} (collection size is evaluated)</li>
+ * <li>{@code Map} (map size is evaluated)</li>
+ * <li>Array (array length is evaluated)</li>
+ * </ul>
  *
  * @author Hardy Ferentschik
- * @see Character#isWhitespace(char)
  */
 @Constraint
 @Documented

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/Past.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/Past.java
@@ -14,7 +14,7 @@ import java.lang.annotation.Target;
 /**
  * The annotated element must be an instant, date or time in the past.
  *
- * <p><i>Now</i> is defined by the {@link Clock} Supplier attached to the {@link Validator}. The
+ * <p><i>Now</i> is defined by the {@code Clock} Supplier attached to the {@code Validator}. The
  * default clock defines the current time according to the virtual machine, applying the current
  * default time zone if needed.
  *

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/PastOrPresent.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/PastOrPresent.java
@@ -1,27 +1,21 @@
 package io.avaje.validation.constraints;
 
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.ElementType.TYPE_USE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-import java.time.Clock;
-import java.time.Year;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
 
 /**
  * The annotated element must be an instant, date or time in the past or in the present.
  *
- * <p><i>Now</i> is defined by the {@link Clock} Supplier attached to the {@link Validator}. The
+ * <p><i>Now</i> is defined by the {@code Clock} Supplier attached to the {@code Validator}. The
  * default clock defines the current time according to the virtual machine, applying the current
  * default time zone if needed.
  *
  * <p>The notion of present is defined relatively to the type on which the constraint is used. For
- * instance, if the constraint is on a {@link Year}, present would mean the whole current year.
+ * instance, if the constraint is on a {@code Year}, present would mean the whole current year.
  *
  * <p>Supported types are:
  *

--- a/validator-constraints/src/main/java/io/avaje/validation/constraints/RegexFlag.java
+++ b/validator-constraints/src/main/java/io/avaje/validation/constraints/RegexFlag.java
@@ -1,4 +1,5 @@
 package io.avaje.validation.constraints;
+
 /** Possible Regexp flags. */
 public enum RegexFlag {
 


### PR DESCRIPTION
Question occurred during authoring: Why does `NotBlank` have the `#max()` field?

- the test suite appears to actually use this property
- Jakarta doesn't seem to have it

@SentryMan answered with quote - https://github.com/avaje/avaje-validator/issues/103

Reasoning here seems good, but the documentation for this feature seems like it may need to be amended?
I genuinely thought it was a mistaken inclusion at first.
(test suite was the only thing that stopped me nuking it (: )