### PR TITLE
Support Inherited Generic Field Types

### DIFF
--- a/blackbox-test/src/main/java/example/avaje/inherit/ConcreteWithGenericBase.java
+++ b/blackbox-test/src/main/java/example/avaje/inherit/ConcreteWithGenericBase.java
@@ -1,0 +1,25 @@
+package example.avaje.inherit;
+
+import io.avaje.validation.constraints.NotBlank;
+import io.avaje.validation.constraints.NotNull;
+import io.avaje.validation.constraints.Valid;
+
+@Valid
+public class ConcreteWithGenericBase extends GenericBase<ConcreteWithGenericBase.InnerConfig> {
+
+  public ConcreteWithGenericBase(InnerConfig config) {
+    super(config);
+  }
+
+  public static class InnerConfig {
+
+    @NotBlank public String value;
+
+    @NotNull public String code;
+
+    public InnerConfig(String value, String code) {
+      this.value = value;
+      this.code = code;
+    }
+  }
+}

--- a/blackbox-test/src/main/java/example/avaje/inherit/ConcreteWithGenericBase.java
+++ b/blackbox-test/src/main/java/example/avaje/inherit/ConcreteWithGenericBase.java
@@ -11,6 +11,7 @@ public class ConcreteWithGenericBase extends GenericBase<ConcreteWithGenericBase
     super(config);
   }
 
+  @Valid
   public static class InnerConfig {
 
     @NotBlank public String value;

--- a/blackbox-test/src/main/java/example/avaje/inherit/GenericBase.java
+++ b/blackbox-test/src/main/java/example/avaje/inherit/GenericBase.java
@@ -1,0 +1,19 @@
+package example.avaje.inherit;
+
+import io.avaje.validation.constraints.Valid;
+
+public abstract class GenericBase<T> {
+  @Valid private T config;
+
+  public GenericBase(T config) {
+    this.config = config;
+  }
+
+  public T getConfig() {
+    return config;
+  }
+
+  public void setConfig(T config) {
+    this.config = config;
+  }
+}

--- a/blackbox-test/src/test/java/example/avaje/inherit/ConcreteWithGenericBaseTest.java
+++ b/blackbox-test/src/test/java/example/avaje/inherit/ConcreteWithGenericBaseTest.java
@@ -1,0 +1,51 @@
+package example.avaje.inherit;
+
+import io.avaje.validation.ConstraintViolation;
+import io.avaje.validation.ConstraintViolationException;
+import io.avaje.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+class ConcreteWithGenericBaseTest {
+
+  final Validator validator = Validator.builder().build();
+
+  @Test
+  void valid() {
+    var bean = new ConcreteWithGenericBase(new ConcreteWithGenericBase.InnerConfig("hello", "code1"));
+    validator.validate(bean);
+  }
+
+  @Test
+  void cascadeValidation_blankValue() {
+    var bean = new ConcreteWithGenericBase(new ConcreteWithGenericBase.InnerConfig("", "code1"));
+    var violation = one(bean);
+    assertThat(violation.path()).contains("value");
+    assertThat(violation.message()).isEqualTo("must not be blank");
+  }
+
+  @Test
+  void cascadeValidation_nullCode() {
+    var bean = new ConcreteWithGenericBase(new ConcreteWithGenericBase.InnerConfig("hello", null));
+    var violation = one(bean);
+    assertThat(violation.path()).contains("code");
+    assertThat(violation.message()).isEqualTo("must not be null");
+  }
+
+  ConstraintViolation one(Object bean) {
+    try {
+      validator.validate(bean);
+      fail("expected violation");
+      return null;
+    } catch (ConstraintViolationException e) {
+      List<ConstraintViolation> violations = new ArrayList<>(e.violations());
+      assertThat(violations).hasSize(1);
+      return violations.get(0);
+    }
+  }
+}

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
@@ -18,6 +18,7 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
 
 record ElementAnnotationContainer(
     UType genericType,
@@ -27,6 +28,10 @@ record ElementAnnotationContainer(
     List<Entry<UType, String>> typeUse2,
     List<Entry<UType, String>> crossParam) {
 
+  static ElementAnnotationContainer create(Element element, TypeMirror resolvedType) {
+    return create(element, UType.parse(resolvedType));
+  }
+
   static ElementAnnotationContainer create(Element element) {
     UType uType;
     if (element instanceof final ExecutableElement executableElement) {
@@ -34,7 +39,10 @@ record ElementAnnotationContainer(
     } else {
       uType = UType.parse(element.asType());
     }
+    return create(element, uType);
+  }
 
+  private static ElementAnnotationContainer create(Element element, UType uType) {
     final var hasValid =
       ValidPrism.isPresent(element)
         || uType.annotations().stream().anyMatch(ValidPrism::isInstance);

--- a/validator-generator/src/main/java/io/avaje/validation/generator/FieldReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/FieldReader.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
 
 final class FieldReader {
 
@@ -28,15 +29,25 @@ final class FieldReader {
   private final boolean usePrimitiveValidation;
 
   FieldReader(Element element, List<String> genericTypeParams) {
-    this(element, genericTypeParams, false);
+    this(element, null, genericTypeParams, false);
+  }
+
+  FieldReader(Element element, TypeMirror resolvedType, List<String> genericTypeParams) {
+    this(element, resolvedType, genericTypeParams, false);
   }
 
   FieldReader(Element element, List<String> genericTypeParams, boolean classLevel) {
+    this(element, null, genericTypeParams, classLevel);
+  }
+
+  private FieldReader(Element element, TypeMirror resolvedType, List<String> genericTypeParams, boolean classLevel) {
     this.genericTypeParams = genericTypeParams;
     this.fieldName = element.getSimpleName().toString();
     this.publicField = Util.isPublic(element);
     this.element = element;
-    this.elementAnnotations = ElementAnnotationContainer.create(element);
+    this.elementAnnotations = resolvedType != null
+        ? ElementAnnotationContainer.create(element, resolvedType)
+        : ElementAnnotationContainer.create(element);
     this.genericType = elementAnnotations.genericType();
     final String shortType = genericType.shortWithoutAnnotations();
     this.usePrimitiveValidation = isPrimitiveValidationType(shortType) && elementAnnotations.supportsPrimitiveValidation();

--- a/validator-generator/src/main/java/io/avaje/validation/generator/TypeReader.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/TypeReader.java
@@ -20,6 +20,8 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
 
 /**
  * Read points for field injection and method injection on baseType plus inherited injection points.
@@ -60,11 +62,15 @@ final class TypeReader {
   }
 
   void read(TypeElement type) {
+    read(type, null);
+  }
+
+  private void read(TypeElement type, DeclaredType superContext) {
     final List<FieldReader> localFields = new ArrayList<>();
     for (final Element element : type.getEnclosedElements()) {
       switch (element.getKind()) {
         case FIELD:
-          readField(element, localFields);
+          readField(element, localFields, superContext);
           break;
         case METHOD:
           readMethod(element, type, localFields);
@@ -90,6 +96,10 @@ final class TypeReader {
   }
 
   private void readField(Element element, List<FieldReader> localFields) {
+    readField(element, localFields, null);
+  }
+
+  private void readField(Element element, List<FieldReader> localFields, DeclaredType superContext) {
     final Element mixInField = mixInFields.get(element.getSimpleName().toString());
     if (mixInField != null && APContext.types().isSameType(mixInField.asType(), element.asType())) {
 
@@ -112,11 +122,28 @@ final class TypeReader {
         || !element.getModifiers().contains(Modifier.STATIC)
             && Util.isNonNullable(element)) {
       seenFields.add(element.toString());
-      var reader = new FieldReader(element, genericTypeParams);
+      final TypeMirror resolvedType = resolveFieldType(element, superContext);
+      var reader = new FieldReader(element, resolvedType, genericTypeParams);
       if (reader.hasConstraints() || ValidPrism.isPresent(element)) {
         localFields.add(reader);
       }
     }
+  }
+
+  private static TypeMirror resolveFieldType(Element element, DeclaredType superContext) {
+    if (superContext == null) return null;
+    try {
+      return APContext.types().asMemberOf(superContext, element);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  private static DeclaredType toDeclaredType(TypeMirror mirror) {
+    if (mirror instanceof DeclaredType) {
+      return (DeclaredType) mirror;
+    }
+    return null;
   }
 
   private List<String> initTypeParams(TypeElement beanType) {
@@ -259,7 +286,7 @@ final class TypeReader {
     }
     final TypeElement superElement = superOf(baseType);
     if (superElement != null) {
-      addSuperType(superElement);
+      addSuperType(superElement, toDeclaredType(baseType.getSuperclass()));
     }
     processCompleted();
   }
@@ -269,10 +296,17 @@ final class TypeReader {
   }
 
   private void addSuperType(TypeElement element) {
+    addSuperType(element, null);
+  }
+
+  private void addSuperType(TypeElement element, DeclaredType concreteType) {
     final String type = element.getQualifiedName().toString();
     if (!JAVA_LANG_OBJECT.equals(type) && !type.contains("<")) {
-      read(element);
-      addSuperType(superOf(element));
+      read(element, concreteType);
+      final TypeElement nextSuper = superOf(element);
+      if (nextSuper != null) {
+        addSuperType(nextSuper, toDeclaredType(element.getSuperclass()));
+      }
     }
   }
 

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/inherit/ConcreteWithGenericBase.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/inherit/ConcreteWithGenericBase.java
@@ -1,0 +1,20 @@
+package io.avaje.validation.generator.models.valid.inherit;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Valid
+public class ConcreteWithGenericBase extends GenericBase<ConcreteWithGenericBase.InnerConfig> {
+
+  public ConcreteWithGenericBase(InnerConfig config) {
+    super(config);
+  }
+
+  public static class InnerConfig {
+
+    @NotBlank public String value;
+
+    @NotNull public String code;
+  }
+}

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/inherit/ConcreteWithGenericBase.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/inherit/ConcreteWithGenericBase.java
@@ -11,6 +11,7 @@ public class ConcreteWithGenericBase extends GenericBase<ConcreteWithGenericBase
     super(config);
   }
 
+  @Valid
   public static class InnerConfig {
 
     @NotBlank public String value;

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/inherit/GenericBase.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/inherit/GenericBase.java
@@ -1,0 +1,19 @@
+package io.avaje.validation.generator.models.valid.inherit;
+
+import io.avaje.validation.constraints.Valid;
+
+public abstract class GenericBase<T> {
+  @Valid private T config;
+
+  public GenericBase(T config) {
+    this.config = config;
+  }
+
+  public T getConfig() {
+    return config;
+  }
+
+  public void setConfig(T config) {
+    this.config = config;
+  }
+}

--- a/validator/src/main/java/io/avaje/validation/core/DMessage.java
+++ b/validator/src/main/java/io/avaje/validation/core/DMessage.java
@@ -4,7 +4,7 @@ import io.avaje.validation.adapter.ValidationContext;
 
 import java.util.Map;
 
-record DMessage(String template, Map<String, Object> attributes, int dedupNumber)
+record DMessage(String template, Map<String, Object> attributes, String lookupkey)
     implements ValidationContext.Message {
 
   // templates can be the same across multiple adapters
@@ -15,8 +15,7 @@ record DMessage(String template, Map<String, Object> attributes, int dedupNumber
     this(template, attributes, messageCounter++);
   }
 
-  @Override
-  public String lookupkey() {
-    return template + dedupNumber;
+  DMessage(String template, Map<String, Object> attributes, int dedupNumber) {
+    this(template, attributes, template + dedupNumber);
   }
 }

--- a/validator/src/main/java/io/avaje/validation/core/DMessage.java
+++ b/validator/src/main/java/io/avaje/validation/core/DMessage.java
@@ -12,10 +12,6 @@ record DMessage(String template, Map<String, Object> attributes, String lookupke
   private static int messageCounter = 0;
 
   DMessage(String template, Map<String, Object> attributes) {
-    this(template, attributes, messageCounter++);
-  }
-
-  DMessage(String template, Map<String, Object> attributes, int dedupNumber) {
-    this(template, attributes, template + dedupNumber);
+    this(template, attributes, template + messageCounter++);
   }
 }


### PR DESCRIPTION
basically https://github.com/avaje/avaje-jsonb/pull/505 but for validator

When a class extended a generic base `Test extends Base<Test.Config>`,  `addSuperType` read the parent's fields using    
  `element.asType()` which returned the raw  `T` rather than the concrete type `Test.Config`. 

- use `Types.asMemberOf(DeclaredType, Element)` to resolve the inherited type mirror. 
- simplify Dmessage