### PR TITLE
Fix repeated constraint annotations being silently dropped

### DIFF
--- a/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
@@ -134,9 +134,9 @@ record ElementAnnotationContainer(
 
   /**
    * When a repeatable annotation (e.g. {@code @Size}) is applied more than once to the same
-   * element, javac collapses the individual mirrors into a single mirror of the generated
-   * container type (e.g. {@code Size.Sizes}). Expand any such container mirror back into its
-   * contained mirrors so repeated constraints are not silently dropped.
+   * element, javac collapses the individual mirrors into a single mirror of the generated container
+   * type (e.g. {@code Size.Sizes}). Expand any such container mirror back into its contained
+   * mirrors so repeated constraints are not silently dropped.
    */
   private static Stream<AnnotationMirror> expandRepeatable(AnnotationMirror mirror) {
     final var containerType = mirror.getAnnotationType();
@@ -148,34 +148,28 @@ record ElementAnnotationContainer(
   }
 
   private static TypeMirror containerValueComponentType(DeclaredType containerType) {
-    for (final ExecutableElement method : ElementFilter.methodsIn(containerType.asElement().getEnclosedElements())) {
-      if ("value".contentEquals(method.getSimpleName()) && method.getReturnType().getKind() == TypeKind.ARRAY) {
+    for (final ExecutableElement method :
+        ElementFilter.methodsIn(containerType.asElement().getEnclosedElements())) {
+      if ("value".contentEquals(method.getSimpleName())
+          && method.getReturnType().getKind() == TypeKind.ARRAY) {
         return ((ArrayType) method.getReturnType()).getComponentType();
       }
     }
     return null;
   }
 
-  private static boolean isRepeatableContainerOf(TypeMirror componentType, DeclaredType containerType) {
+  private static boolean isRepeatableContainerOf(
+      TypeMirror componentType, DeclaredType containerType) {
     if (componentType.getKind() != TypeKind.DECLARED) {
       return false;
     }
     final var componentElement = ((DeclaredType) componentType).asElement();
-    for (final AnnotationMirror meta : componentElement.getAnnotationMirrors()) {
-      final var metaElement = (TypeElement) meta.getAnnotationType().asElement();
-      if ("java.lang.annotation.Repeatable".contentEquals(metaElement.getQualifiedName())) {
-        for (final var entry : meta.getElementValues().entrySet()) {
-          if ("value".contentEquals(entry.getKey().getSimpleName())
-              && entry.getValue().getValue() instanceof final TypeMirror repeatContainer) {
-            return APContext.types().isSameType(repeatContainer, containerType);
-          }
-        }
-      }
-    }
-    return false;
+    return RepeatablePrism.getOptionalOn(componentElement)
+        .map(RepeatablePrism::value)
+        .filter(repeatContainer -> APContext.types().isSameType(repeatContainer, containerType))
+        .isPresent();
   }
 
-  @SuppressWarnings("unchecked")
   private static List<AnnotationMirror> containedMirrors(AnnotationMirror mirror) {
     for (final var entry : mirror.getElementValues().entrySet()) {
       if ("value".contentEquals(entry.getKey().getSimpleName())

--- a/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/ElementAnnotationContainer.java
@@ -15,10 +15,15 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
 
 record ElementAnnotationContainer(
     UType genericType,
@@ -63,6 +68,7 @@ record ElementAnnotationContainer(
 
   private static List<Entry<UType, String>> annotations(Element element, UType uType, List<Entry<UType, String>> crossParam) {
     return Stream.concat(element.getAnnotationMirrors().stream(), uType.annotations().stream())
+      .flatMap(ElementAnnotationContainer::expandRepeatable)
       .filter(a -> excludePlainValid(a, element))
       .filter(ElementAnnotationContainer::hasMetaConstraintAnnotation)
       .map(a -> {
@@ -116,6 +122,7 @@ record ElementAnnotationContainer(
   private static List<Entry<UType, String>> typeUseFor(UType uType, Element element) {
     return Optional.ofNullable(uType).map(UType::annotations).stream()
       .flatMap(List::stream)
+      .flatMap(ElementAnnotationContainer::expandRepeatable)
       .filter(ElementAnnotationContainer::hasMetaConstraintAnnotation)
       .map(a -> checkType(element, uType, a))
       .map(a ->
@@ -123,6 +130,64 @@ record ElementAnnotationContainer(
           UType.parse(a.getAnnotationType()),
           AnnotationUtil.annotationAttributeMap(a, element)))
       .toList();
+  }
+
+  /**
+   * When a repeatable annotation (e.g. {@code @Size}) is applied more than once to the same
+   * element, javac collapses the individual mirrors into a single mirror of the generated
+   * container type (e.g. {@code Size.Sizes}). Expand any such container mirror back into its
+   * contained mirrors so repeated constraints are not silently dropped.
+   */
+  private static Stream<AnnotationMirror> expandRepeatable(AnnotationMirror mirror) {
+    final var containerType = mirror.getAnnotationType();
+    final var componentType = containerValueComponentType(containerType);
+    if (componentType != null && isRepeatableContainerOf(componentType, containerType)) {
+      return containedMirrors(mirror).stream();
+    }
+    return Stream.of(mirror);
+  }
+
+  private static TypeMirror containerValueComponentType(DeclaredType containerType) {
+    for (final ExecutableElement method : ElementFilter.methodsIn(containerType.asElement().getEnclosedElements())) {
+      if ("value".contentEquals(method.getSimpleName()) && method.getReturnType().getKind() == TypeKind.ARRAY) {
+        return ((ArrayType) method.getReturnType()).getComponentType();
+      }
+    }
+    return null;
+  }
+
+  private static boolean isRepeatableContainerOf(TypeMirror componentType, DeclaredType containerType) {
+    if (componentType.getKind() != TypeKind.DECLARED) {
+      return false;
+    }
+    final var componentElement = ((DeclaredType) componentType).asElement();
+    for (final AnnotationMirror meta : componentElement.getAnnotationMirrors()) {
+      final var metaElement = (TypeElement) meta.getAnnotationType().asElement();
+      if ("java.lang.annotation.Repeatable".contentEquals(metaElement.getQualifiedName())) {
+        for (final var entry : meta.getElementValues().entrySet()) {
+          if ("value".contentEquals(entry.getKey().getSimpleName())
+              && entry.getValue().getValue() instanceof final TypeMirror repeatContainer) {
+            return APContext.types().isSameType(repeatContainer, containerType);
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<AnnotationMirror> containedMirrors(AnnotationMirror mirror) {
+    for (final var entry : mirror.getElementValues().entrySet()) {
+      if ("value".contentEquals(entry.getKey().getSimpleName())
+          && entry.getValue().getValue() instanceof final List<?> values) {
+        final var result = new ArrayList<AnnotationMirror>(values.size());
+        for (final var value : values) {
+          result.add((AnnotationMirror) ((AnnotationValue) value).getValue());
+        }
+        return result;
+      }
+    }
+    return List.of();
   }
 
   static boolean hasMetaConstraintAnnotation(AnnotationMirror m) {

--- a/validator-generator/src/main/java/io/avaje/validation/generator/package-info.java
+++ b/validator-generator/src/main/java/io/avaje/validation/generator/package-info.java
@@ -11,6 +11,7 @@
 @GeneratePrism(org.jspecify.annotations.NullUnmarked.class)
 @GeneratePrism(org.jspecify.annotations.NonNull.class)
 @GeneratePrism(io.avaje.validation.ValidMethod.class)
+@GeneratePrism(java.lang.annotation.Repeatable.class)
 @JStacheConfig(type = JStacheType.STACHE)
 package io.avaje.validation.generator;
 

--- a/validator-generator/src/test/java/io/avaje/validation/generator/ValidatorProcessorTest.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/ValidatorProcessorTest.java
@@ -13,6 +13,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Set;
 
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaCompiler.CompilationTask;
 import javax.tools.JavaFileObject;
@@ -61,11 +63,24 @@ class ValidatorProcessorTest {
     final Iterable<JavaFileObject> files =
         manager.list(StandardLocation.SOURCE_PATH, "", fileKinds, true);
 
+    final DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
     final CompilationTask task =
         compiler.getTask(
-            new PrintWriter(System.out), null, null, Arrays.asList("--release=" + Integer.getInteger("java.specification.version")), null, files);
+            new PrintWriter(System.out), null, diagnostics, Arrays.asList("--release=" + Integer.getInteger("java.specification.version")), null, files);
     task.setProcessors(Arrays.asList(new ValidationProcessor()));
 
     assertThat(task.call()).isTrue();
+
+    final boolean repeatedConstraintsWarned =
+        diagnostics.getDiagnostics().stream()
+            .filter(d -> d.getKind() == Diagnostic.Kind.MANDATORY_WARNING || d.getKind() == Diagnostic.Kind.WARNING)
+            .anyMatch(
+                d ->
+                    d.getSource() != null
+                        && d.getSource().toString().contains("RepeatedConstraints")
+                        && d.getMessage(null).contains("No Constraints Defined"));
+    assertThat(repeatedConstraintsWarned)
+        .as("repeated constraint annotations on the same field should not be dropped")
+        .isFalse();
   }
 }

--- a/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/RepeatedConstraints.java
+++ b/validator-generator/src/test/java/io/avaje/validation/generator/models/valid/RepeatedConstraints.java
@@ -1,0 +1,12 @@
+package io.avaje.validation.generator.models.valid;
+
+import java.util.List;
+
+import io.avaje.validation.constraints.Valid;
+import jakarta.validation.constraints.Size;
+
+@Valid
+public record RepeatedConstraints(
+    @Size(min = 1)
+    @Size(max = 5)
+    List<String> tags) {}


### PR DESCRIPTION
## Summary
- javac collapses a repeatable constraint annotation applied twice on the same element (e.g. `@Size(min=1) @Size(max=5)`) into a single mirror of the generated container type (e.g. `Size.Sizes`). That container isn't itself meta-annotated with `@Constraint`, so it was filtered out entirely, leaving zero constraints collected for the element.
- This produced the `No Constraints Defined` warning and skipped adapter generation, which then surfaced only at runtime as `IllegalArgumentException: No ValidationAdapter for class ...`.
- `ElementAnnotationContainer` now expands any such repeatable-container mirror back into its individual annotation mirrors before the `@Constraint` filter runs, so each repeated constraint is picked up and chained into the generated adapter via `.andThen(...)`.

Fixes #385